### PR TITLE
fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생

### DIFF
--- a/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
+++ b/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
@@ -1,23 +1,26 @@
 package sevenstar.marineleisure.member.controller;
 
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import sevenstar.marineleisure.global.domain.BaseResponse;
-import sevenstar.marineleisure.global.exception.enums.CommonErrorCode;
 import sevenstar.marineleisure.global.exception.enums.MemberErrorCode;
 import sevenstar.marineleisure.member.dto.AuthCodeRequest;
 import sevenstar.marineleisure.member.dto.LoginResponse;
 import sevenstar.marineleisure.member.service.AuthService;
 import sevenstar.marineleisure.member.service.OauthService;
-
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * 인증 관련 요청을 처리하는 컨트롤러
@@ -30,22 +33,6 @@ public class AuthController {
 
 	private final OauthService oauthService;
 	private final AuthService authService;
-
-	/**
-	 * GET /auth/kakao?redirectUri=…
-	 * → 내부에서 state도 생성해서 저장하고,
-	 *    kakaAuthUrl 로 곧장 302 리다이렉트
-	 */
-	@GetMapping("/kakao")
-	public void kakaoLoginRedirect(
-		@RequestParam String redirectUri,
-		HttpServletRequest request,
-		HttpServletResponse resp
-	) throws IOException {
-		Map<String, String> info = oauthService.getKakaoLoginUrl(redirectUri, request);
-		// state는 이제 세션에 저장됨
-		resp.sendRedirect(info.get("kakaoAuthUrl"));
-	}
 
 	/**
 	 * 카카오 로그인 URL 생성

--- a/src/main/java/sevenstar/marineleisure/member/domain/Member.java
+++ b/src/main/java/sevenstar/marineleisure/member/domain/Member.java
@@ -1,6 +1,7 @@
 package sevenstar.marineleisure.member.domain;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,5 +58,10 @@ public class Member extends BaseEntity {
 	public Member update(String nickname) {
 		this.nickname = nickname;
 		return this;
+	}
+	public void updateNickname(String newNickname) {
+		if (!Objects.equals(this.nickname, newNickname)) {
+			this.nickname = newNickname;
+		}
 	}
 }

--- a/src/main/java/sevenstar/marineleisure/member/service/AuthService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/AuthService.java
@@ -49,8 +49,7 @@ public class AuthService {
 		}
 
 		// 3. 사용자 정보 처리 및 회원 조회
-		var userInfo = oauthService.processKakaoUser(accessToken);
-		Member member = oauthService.findUserById((Long)userInfo.get("id"));
+		Member member = oauthService.processKakaoUser(accessToken);
 
 		// 4. JWT 토큰 생성
 		String jwtAccessToken = jwtTokenProvider.createAccessToken(member);
@@ -101,8 +100,10 @@ public class AuthService {
 		}
 
 		// 3. 사용자 정보 처리 및 회원 조회
-		var userInfo = oauthService.processKakaoUser(accessToken);
-		Member member = oauthService.findUserById((Long)userInfo.get("id"));
+		// var userInfo = oauthService.processKakaoUser(accessToken);
+		// Member member = oauthService.findUserById((Long)userInfo.get("id"));
+		Member member = oauthService.processKakaoUser(accessToken);
+
 
 		// 4. JWT 토큰 생성
 		String jwtAccessToken = jwtTokenProvider.createAccessToken(member);

--- a/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
@@ -11,6 +11,7 @@ import sevenstar.marineleisure.member.dto.MemberDetailResponse;
 import sevenstar.marineleisure.member.repository.MemberRepository;
 
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * 회원 관련 비즈니스 로직을 처리하는 서비스
@@ -59,23 +60,4 @@ public class MemberService {
 		return getMemberDetail(memberId);
 	}
 
-
-	/**
-	 * 회원의 닉네임을 업데이트합니다.
-	 *
-	 * @param memberId 업데이트할 회원 ID
-	 * @param nickname 새 닉네임
-	 * @return 업데이트된 회원
-	 * @throws NoSuchElementException 회원을 찾을 수 없는 경우
-	 */
-	@Transactional
-	public Member updateMemberNickname(Long memberId, String nickname) {
-		log.info("회원 닉네임 업데이트: memberId={}, nickname={}", memberId, nickname);
-
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new NoSuchElementException("회원을 찾을 수 없습니다: " + memberId));
-
-		member.update(nickname);
-		return memberRepository.save(member);
-	}
 }

--- a/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
@@ -58,4 +58,24 @@ public class MemberService {
 		log.info("현재 로그인한 회원 상세 정보 조회: memberId={}", memberId);
 		return getMemberDetail(memberId);
 	}
+
+
+	/**
+	 * 회원의 닉네임을 업데이트합니다.
+	 *
+	 * @param memberId 업데이트할 회원 ID
+	 * @param nickname 새 닉네임
+	 * @return 업데이트된 회원
+	 * @throws NoSuchElementException 회원을 찾을 수 없는 경우
+	 */
+	@Transactional
+	public Member updateMemberNickname(Long memberId, String nickname) {
+		log.info("회원 닉네임 업데이트: memberId={}, nickname={}", memberId, nickname);
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new NoSuchElementException("회원을 찾을 수 없습니다: " + memberId));
+
+		member.update(nickname);
+		return memberRepository.save(member);
+	}
 }

--- a/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
@@ -63,7 +63,7 @@ public class OauthService {
 		String finalRedirectUri = customRedirectUri != null ? customRedirectUri : this.redirectUri;
 
 		String kakaoAuthUrl = UriComponentsBuilder.fromUriString(kakaoBaseUri)
-			.path(kakaoPath)
+			.path("/oauth/authorize")
 			.queryParam("client_id", apiKey)
 			.queryParam("redirect_uri", finalRedirectUri)
 			.queryParam("response_type", "code")

--- a/src/main/resources/application-auth.properties
+++ b/src/main/resources/application-auth.properties
@@ -6,9 +6,7 @@ kakao.login.api_key=${KAKAO_API_KEY}
 kakao.login.client_secret=${KAKAO_CLIENT_SECRET}
 
 # code
-kakao.login.redirect_uri=http://localhost:5174/oauth/kakao/callback
+kakao.login.redirect_uri=http://localhost:5173/oauth/kakao/callback
 kakao.login.uri.code=/oauth/authorize
 kakao.login.uri.base=https://kauth.kakao.com
 
-#
-app.client.url="http://localhost:5174"

--- a/src/test/java/sevenstar/marineleisure/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/repository/MemberRepositoryTest.java
@@ -6,7 +6,9 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
+import sevenstar.marineleisure.global.enums.MemberStatus;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -14,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import sevenstar.marineleisure.member.domain.Member;
 
 @DataJpaTest
+@EnableJpaAuditing
 class MemberRepositoryTest {
 
 	@Autowired
@@ -40,6 +43,11 @@ class MemberRepositoryTest {
 		assertThat(foundMember.get().getEmail()).isEqualTo("test@example.com");
 		assertThat(foundMember.get().getProvider()).isEqualTo("kakao");
 		assertThat(foundMember.get().getProviderId()).isEqualTo("12345");
+		assertThat(foundMember.get().getLatitude().compareTo(BigDecimal.valueOf(37.5665))).isEqualTo(0);
+		assertThat(foundMember.get().getLongitude().compareTo(BigDecimal.valueOf(126.9780))).isEqualTo(0);
+		assertThat(foundMember.get().getStatus()).isEqualTo(MemberStatus.ACTIVE);
+		assertThat(foundMember.get().getCreatedAt()).isNotNull();
+		assertThat(foundMember.get().getUpdatedAt()).isNotNull();
 	}
 
 	@Test
@@ -58,6 +66,11 @@ class MemberRepositoryTest {
 		assertThat(foundMember).isPresent();
 		assertThat(foundMember.get().getNickname()).isEqualTo("testUser");
 		assertThat(foundMember.get().getEmail()).isEqualTo("test@example.com");
+		assertThat(foundMember.get().getProvider()).isEqualTo("kakao");
+		assertThat(foundMember.get().getProviderId()).isEqualTo("12345");
+		assertThat(foundMember.get().getLatitude().compareTo(BigDecimal.valueOf(37.5665))).isEqualTo(0);
+		assertThat(foundMember.get().getLongitude().compareTo(BigDecimal.valueOf(126.9780))).isEqualTo(0);
+		assertThat(foundMember.get().getStatus()).isEqualTo(MemberStatus.ACTIVE);
 	}
 
 	@Test
@@ -85,6 +98,17 @@ class MemberRepositoryTest {
 		entityManager.flush();
 		entityManager.clear();
 
+		// 수정 전 상태 저장
+		Member beforeUpdate = memberRepository.findById(savedMember.getId()).orElseThrow();
+		var originalUpdatedAt = beforeUpdate.getUpdatedAt();
+
+		// 잠시 대기하여 updatedAt 변경 확인을 위한 시간차 생성
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
 		// when
 		Member foundMember = memberRepository.findById(savedMember.getId()).orElseThrow();
 		foundMember.update("newNickname");
@@ -95,6 +119,10 @@ class MemberRepositoryTest {
 		// then
 		Member updatedMember = memberRepository.findById(savedMember.getId()).orElseThrow();
 		assertThat(updatedMember.getNickname()).isEqualTo("newNickname");
+		assertThat(updatedMember.getEmail()).isEqualTo("test@example.com");
+		assertThat(updatedMember.getProvider()).isEqualTo("kakao");
+		assertThat(updatedMember.getProviderId()).isEqualTo("12345");
+		assertThat(updatedMember.getUpdatedAt()).isAfter(originalUpdatedAt);
 	}
 
 	@Test

--- a/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
@@ -1,7 +1,8 @@
 package sevenstar.marineleisure.member.service;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,19 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import sevenstar.marineleisure.global.jwt.JwtTokenProvider;
 import sevenstar.marineleisure.global.util.CookieUtil;
 import sevenstar.marineleisure.member.domain.Member;
 import sevenstar.marineleisure.member.dto.KakaoTokenResponse;
 import sevenstar.marineleisure.member.dto.LoginResponse;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -82,19 +77,13 @@ class AuthServiceTest {
 			.expiresIn(3600L)
 			.build();
 
-		// 사용자 정보 설정
-		Map<String, Object> userInfo = new HashMap<>();
-		userInfo.put("id", 1L);
-		userInfo.put("email", "test@example.com");
-		userInfo.put("nickname", "testUser");
-
 		// 쿠키 설정
 		when(cookieUtil.createRefreshTokenCookie(refreshToken)).thenReturn(mockCookie);
 
 		// 서비스 메서드 모킹
 		when(oauthService.exchangeCodeForToken(code)).thenReturn(tokenResponse);
-		when(oauthService.processKakaoUser(accessToken)).thenReturn(userInfo);
-		when(oauthService.findUserById(1L)).thenReturn(testMember);
+		when(oauthService.processKakaoUser(accessToken)).thenReturn(testMember);
+		// findUserById는 이제 필요 없음 (processKakaoUser가 직접 Member를 반환)
 		when(jwtTokenProvider.createAccessToken(testMember)).thenReturn(jwtAccessToken);
 		when(jwtTokenProvider.createRefreshToken(testMember)).thenReturn(refreshToken);
 

--- a/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
@@ -156,13 +156,13 @@ class OauthServiceTest {
 		when(memberRepository.save(any(Member.class))).thenReturn(member);
 
 		// when
-		Map<String, Object> result = oauthService.processKakaoUser(accessToken);
+		Member result = oauthService.processKakaoUser(accessToken);
 
 		// then
 		assertThat(result).isNotNull();
-		assertThat(result.get("id")).isEqualTo(1L);
-		assertThat(result.get("email")).isEqualTo("test@example.com");
-		assertThat(result.get("nickname")).isEqualTo("testUser");
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getEmail()).isEqualTo("test@example.com");
+		assertThat(result.getNickname()).isEqualTo("testUser");
 	}
 
 	@Test
@@ -209,13 +209,13 @@ class OauthServiceTest {
 		when(memberRepository.save(any(Member.class))).thenReturn(updatedMember);
 
 		// when
-		Map<String, Object> result = oauthService.processKakaoUser(accessToken);
+		Member result = oauthService.processKakaoUser(accessToken);
 
 		// then
 		assertThat(result).isNotNull();
-		assertThat(result.get("id")).isEqualTo(1L);
-		assertThat(result.get("email")).isEqualTo("test@example.com");
-		assertThat(result.get("nickname")).isEqualTo("newNickname");
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getEmail()).isEqualTo("test@example.com");
+		assertThat(result.getNickname()).isEqualTo("newNickname");
 	}
 
 	@Test


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- orElse 즉시 실행으로 인한 중복 INSERT 방지

## 📝 관련 이슈

### 문제 원인
Optional.orElse(...)는 항상 인자를 평가합니다.
따라서 기존 회원이 존재해도 save(new Member(...))가 실행되어 매번 INSERT 가 시도되고, nickname 컬럼의 UNIQUE 제약에 걸려 예외가 발생했습니다. 

```java
memberRepository.findByProviderAndProviderId(provider, providerId)
    .map(existing -> updateNickname(existing, kakaoNickname))
    .orElse(                             // 즉시 실행
        memberRepository.save(           // 매 호출마다 실행
            new Member(provider, providerId, kakaoNickname, email)
        )
    );
```

### 변경 사항

| 기존 로직 | 수정 후 로직 |
|---------|------------|
| orElse(...) 사용 → 항상 새 엔티티 저장 | orElseGet(...) 사용 → Optional이 비어 있을 때만 실행 |
| map 내부와 orElse 내부에서 각각 save 호출 | 단일 save 호출로 JPA가 INSERT/UPDATE 자동 판단 |

```java
Member member = memberRepository.findByProviderAndProviderId(provider, providerId)
        .orElseGet(() -> Member.builder()
            .provider(provider)
            .providerId(providerId)
            .email(email)
            .nickname(nickname)
            .latitude(BigDecimal.valueOf(0))
            .longitude(BigDecimal.valueOf(0))
            .build());
member.updateNickname(nickname);

// 단일 save 호출로 JPA가 INSERT/UPDATE 자동 판단
return memberRepository.save(member);
```

### 결과

| 시나리오 | DB 동작 |
|---------|--------|
| 최초 로그인 | INSERT 1회 |
| 재로그인 | 기존 엔티티 로드 후 **UPDATE**만 |
| 제약 위반 | 발생하지 않음 |

| 지표| 변경 전| 변경 후 |
|---------|--------|---------|
| 엔티티 객체 생성 | 3개 | 1개|
| INSERT |  3회 | 1회 |
| UPDATE |  1회(오류) | 1회 |
|런타임 예외| 2건(unique 문제) | 0|
- 재 로그인 시에
  - 불필요한 객체 생성 1개 감소
  - 잘못된 insert 제거 (유니크 충돌의 원인)
  - 변경 사항 있을 때만 자동 update 쿼리 발송 (save 특징)
  - 잘못된 insert로 인한 예외 발생하지 않는다.
## 스크린샷

## 주의사항

Closes #38 
