### PR TITLE
fix: application-prod.yml에서 쿠키를 쓸지 말지 결정할 수 있게 수정

### DIFF
--- a/src/main/java/sevenstar/marineleisure/global/config/SecurityConfig.java
+++ b/src/main/java/sevenstar/marineleisure/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package sevenstar.marineleisure.global.config;
 
 import java.util.Arrays;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -27,6 +28,9 @@ public class SecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Value("${jwt.use-cookie:true}")
+	private boolean useCookie;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -75,7 +79,10 @@ public class SecurityConfig {
 
 		config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));
-		config.setAllowCredentials(true);
+
+		// jwt.use-cookie 설정에 따라 credentials 설정 변경
+		// useCookie=true 일 때만 allowCredentials=true (쿠키 사용)
+		config.setAllowCredentials(useCookie);
 		config.setMaxAge(3600L); // 프리플라이트 요청 캐싱 (1시간)
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/sevenstar/marineleisure/global/util/CookieUtil.java
+++ b/src/main/java/sevenstar/marineleisure/global/util/CookieUtil.java
@@ -1,75 +1,114 @@
 package sevenstar.marineleisure.global.util;
 
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.stereotype.Component;
-
 /**
  * 쿠키 관리 유틸리티
  * 쿠키 생성, 조회, 삭제 로직을 담당합니다.
+ * jwt.use-cookie 설정에 따라 쿠키 설정을 다르게 적용합니다.
  */
 @Component
 public class CookieUtil {
 
-	/**
-	 * 리프레시 토큰 쿠키 생성
-	 *
-	 * @param refreshToken 리프레시 토큰
-	 * @return 생성된 쿠키
-	 */
-	public Cookie createRefreshTokenCookie(String refreshToken) {
-		Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
-		refreshTokenCookie.setHttpOnly(true);
-		refreshTokenCookie.setSecure(true);
-		refreshTokenCookie.setPath("/");
-		refreshTokenCookie.setMaxAge((int)(14 * 24 * 60 * 60)); // 14일
-		refreshTokenCookie.setAttribute("SameSite", "None");
-		return refreshTokenCookie;
-	}
+    @Value("${jwt.use-cookie:true}")
+    private boolean useCookie;
 
-	/**
-	 * 리프레시 토큰 쿠키 삭제
-	 *
-	 * @return 삭제용 쿠키
-	 */
-	public Cookie deleteRefreshTokenCookie() {
-		Cookie refreshTokenCookie = new Cookie("refresh_token", "");
-		refreshTokenCookie.setHttpOnly(true);
-		refreshTokenCookie.setSecure(true);
-		refreshTokenCookie.setPath("/");
-		refreshTokenCookie.setMaxAge(0); // 쿠키 즉시 만료
-		refreshTokenCookie.setAttribute("SameSite", "None");
-		return refreshTokenCookie;
-	}
+    /**
+     * 리프레시 토큰 쿠키 생성
+     * jwt.use-cookie 설정에 따라 쿠키 설정이 달라집니다.
+     * - useCookie=false: secure=false, sameSite=Lax
+     * - useCookie=true: secure=true, sameSite=None
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 생성된 쿠키
+     */
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        boolean useSecureCookie = useCookie;
 
-	/**
-	 * 쿠키 조회
-	 *
-	 * @param request HTTP 요청
-	 * @param name 쿠키 이름
-	 * @return 찾은 쿠키 또는 null
-	 */
-	public Cookie getCookie(HttpServletRequest request, String name) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if (cookie.getName().equals(name)) {
-					return cookie;
-				}
-			}
-		}
-		return null;
-	}
+        // Create a standard Cookie
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(useSecureCookie);
+        cookie.setPath("/");
+        cookie.setMaxAge((int) Duration.ofDays(14).toSeconds());
 
-	/**
-	 * 쿠키 추가
-	 *
-	 * @param response HTTP 응답
-	 * @param cookie 추가할 쿠키
-	 */
-	public void addCookie(HttpServletResponse response, Cookie cookie) {
-		response.addCookie(cookie);
-	}
+        // Set SameSite attribute
+        if (useSecureCookie) {
+            cookie.setAttribute("SameSite", "None");
+        } else {
+            cookie.setAttribute("SameSite", "Lax");
+        }
+
+        return cookie;
+    }
+
+    /**
+     * 리프레시 토큰 쿠키 삭제
+     * jwt.use-cookie 설정에 따라 쿠키 설정이 달라집니다.
+     *
+     * @return 삭제용 쿠키
+     */
+    public Cookie deleteRefreshTokenCookie() {
+        boolean useSecureCookie = useCookie;
+
+        Cookie cookie = new Cookie("refresh_token", "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(useSecureCookie);
+        cookie.setPath("/");
+        cookie.setMaxAge(0); // 쿠키 즉시 만료
+
+        // Set SameSite attribute
+        if (useSecureCookie) {
+            cookie.setAttribute("SameSite", "None");
+        } else {
+            cookie.setAttribute("SameSite", "Lax");
+        }
+
+        return cookie;
+    }
+
+    /**
+     * 쿠키 조회
+     *
+     * @param request HTTP 요청
+     * @param name 쿠키 이름
+     * @return 찾은 쿠키 또는 null
+     */
+    public Cookie getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return cookie;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키 추가
+     *
+     * @param response HTTP 응답
+     * @param cookie 추가할 쿠키
+     */
+    public void addCookie(HttpServletResponse response, Cookie cookie) {
+        response.addCookie(cookie);
+    }
+
+    /**
+     * 현재 설정이 쿠키를 사용하는지 여부 반환
+     * 
+     * @return jwt.use-cookie 설정값
+     */
+    public boolean isUsingCookie() {
+        return useCookie;
+    }
 }

--- a/src/main/java/sevenstar/marineleisure/member/dto/LoginResponse.java
+++ b/src/main/java/sevenstar/marineleisure/member/dto/LoginResponse.java
@@ -1,21 +1,73 @@
 package sevenstar.marineleisure.member.dto;
 
 import lombok.Builder;
+import sevenstar.marineleisure.member.domain.Member;
 
 /**
  * 로그인 성공 시 반환되는 DTO
  * Access 토큰과 사용자 정보를 포함
- * Refresh 토큰은 쿠키로 전송
+ * Refresh 토큰은 jwt.use-cookie 설정에 따라 쿠키 또는 응답 본문으로 전송
  * @param accessToken
  * @param userId
  * @param email
  * @param nickname
+ * @param refreshToken jwt.use-cookie=false 설정일 때만 사용 (쿠키 대신 응답 본문에 포함)
  */
 @Builder
 public record LoginResponse(
 	String accessToken,
 	Long userId,
 	String email,
-	String nickname
+	String nickname,
+	String refreshToken
 ) {
+	/**
+	 * 쿠키 방식 사용 시 (jwt.use-cookie=true) 생성자
+	 */
+	public static LoginResponse of(String accessToken, Long userId, String email, String nickname) {
+		return LoginResponse.builder()
+			.accessToken(accessToken)
+			.userId(userId)
+			.email(email)
+			.nickname(nickname)
+			.build();
+	}
+
+	/**
+	 * JSON 응답 방식 사용 시 (jwt.use-cookie=false) 생성자
+	 */
+	public static LoginResponse of(String accessToken, Long userId, String email, String nickname, String refreshToken) {
+		return LoginResponse.builder()
+			.accessToken(accessToken)
+			.userId(userId)
+			.email(email)
+			.nickname(nickname)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	/**
+	 * 사용자 정보와 액세스 토큰만으로 생성하는 편의 메서드
+	 */
+	public static LoginResponse of(String accessToken, Member member) {
+		return LoginResponse.builder()
+			.accessToken(accessToken)
+			.userId(member.getId())
+			.email(member.getEmail())
+			.nickname(member.getNickname())
+			.build();
+	}
+
+	/**
+	 * 사용자 정보와 액세스 토큰, 리프레시 토큰으로 생성하는 편의 메서드 (jwt.use-cookie=false 설정용)
+	 */
+	public static LoginResponse of(String accessToken, Member member, String refreshToken) {
+		return LoginResponse.builder()
+			.accessToken(accessToken)
+			.userId(member.getId())
+			.email(member.getEmail())
+			.nickname(member.getNickname())
+			.refreshToken(refreshToken)
+			.build();
+	}
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,8 +13,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
-  redis:
-    ssl: false
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/marine
@@ -60,3 +58,9 @@ kakao:
     uri:
       code: /oauth/authorize
       base: https://kauth.kakao.com
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity-in-seconds: 300
+  refresh-token-validity-in-seconds: 86400  # 24시간
+  use-cookie: false # 개발 환경에서. 클라이언트 개발 완료 후 쿠키 사용 방식으로 변경.


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
# JWT 토큰 전달 방식 변경 구현 요약
- JWT 토큰 전달 방식을 `jwt.use-cookie` 설정에 따라 다르게 구현
- **jwt.use-cookie=false**: HTTP 환경에서 쿠키를 사용하지 않고 `Bearer` 헤더 + JSON 필드로 토큰 전달
- **jwt.use-cookie=true**: HTTPS 환경에서 쿠키를 사용하여 토큰 전달

## 변경 파일 목록
1. `application-prod.yml` - 프로덕션 환경 설정 파일
2. `LoginResponse.java` - 로그인 응답 DTO
3. `CookieUtil.java` - 쿠키 관리 유틸리티
4. `AuthService.java` - 인증 서비스
5. `AuthController.java` - 인증 컨트롤러
6. `SecurityConfig.java` - 보안 설정

## 상세 변경 내용

### 1. 프로필 분기용 설정 추가

#### `application-prod.yml`
```yaml
jwt:
  secret: ${JWT_SECRET}
  access-token-validity-in-seconds: 300
  refresh-token-validity-in-seconds: 86400  # 24시간
  use-cookie: false  # 프로덕션 환경에서는 쿠키 = true. 개발 환경에서는 쿠키 = false 
```

### 2. `LoginResponse.java` 수정
- 리프레시 토큰을 응답에 포함할 수 있도록 필드 추가
- jwt.use-cookie 설정에 따라 다른 응답을 생성하는 정적 팩토리 메서드 추가

```java
@Builder
public record LoginResponse(
    String accessToken,
    Long userId,
    String email,
    String nickname,
    String refreshToken  // jwt.use-cookie=false 설정일 때만 사용
) {
    // 쿠키 방식 사용 시 (jwt.use-cookie=true) 생성자
    public static LoginResponse of(String accessToken, Member member) {
        return LoginResponse.builder()
            .accessToken(accessToken)
            .userId(member.getId())
            .email(member.getEmail())
            .nickname(member.getNickname())
            .build();
    }

    // JSON 응답 방식 사용 시 (jwt.use-cookie=false) 생성자
    public static LoginResponse of(String accessToken, Member member, String refreshToken) {
        return LoginResponse.builder()
            .accessToken(accessToken)
            .userId(member.getId())
            .email(member.getEmail())
            .nickname(member.getNickname())
            .refreshToken(refreshToken)
            .build();
    }
}
```

### 3. `CookieUtil.java` 수정
- `jwt.use-cookie` 설정값을 주입받아 쿠키 설정을 다르게 적용하도록 수정
- 프로필 체크 로직 제거하고 설정값만으로 판단하도록 단순화

```java
@Component
public class CookieUtil {

    @Value("${jwt.use-cookie:true}")
    private boolean useCookie;

    public Cookie createRefreshTokenCookie(String refreshToken) {
        boolean useSecureCookie = useCookie;

        Cookie cookie = new Cookie("refresh_token", refreshToken);
        cookie.setHttpOnly(true);
        cookie.setSecure(useSecureCookie);  // useCookie=false: secure=false, useCookie=true: secure=true
        cookie.setPath("/");
        cookie.setMaxAge((int) Duration.ofDays(14).toSeconds());

        // SameSite 속성 설정
        if (useSecureCookie) {
            cookie.setAttribute("SameSite", "None");  // useCookie=true: SameSite=None
        } else {
            cookie.setAttribute("SameSite", "Lax");   // useCookie=false: SameSite=Lax
        }

        return cookie;
    }

    // ...
}
```

### 4. `AuthService.java` 수정
- `jwt.use-cookie` 설정값을 주입받아 쿠키 사용 여부 결정
- 설정값에 따라 리프레시 토큰 전달 방식 분기 처리

```java
@Service
@RequiredArgsConstructor
public class AuthService {
    // ...

    @Value("${jwt.use-cookie:true}")
    private boolean useCookie;

    public LoginResponse processKakaoLogin(String code, String state, String encryptedState,
        HttpServletResponse response) {
        // ...

        // jwt.use-cookie 설정에 따라 리프레시 토큰 전달 방식 결정
        if (useCookie) {
            // useCookie=true: 쿠키로 전송
            cookieUtil.addCookie(response, cookieUtil.createRefreshTokenCookie(refreshToken));
            return LoginResponse.of(jwtAccessToken, member);
        } else {
            // useCookie=false: JSON 응답으로 전송
            return LoginResponse.of(jwtAccessToken, member, refreshToken);
        }
    }

    public LoginResponse refreshToken(String refreshToken, HttpServletResponse response) {
        // ...

        // jwt.use-cookie 설정에 따라 리프레시 토큰 전달 방식 결정
        if (useCookie) {
            // useCookie=true: 쿠키로 전송
            cookieUtil.addCookie(response, cookieUtil.createRefreshTokenCookie(newRefreshToken));
            return LoginResponse.of(newAccessToken, member);
        } else {
            // useCookie=false: JSON 응답으로 전송
            return LoginResponse.of(newAccessToken, member, newRefreshToken);
        }
    }
}
```

### 5. `AuthController.java` 수정
- `/auth/refresh` 엔드포인트에서 쿠키 또는 요청 본문에서 리프레시 토큰을 추출하도록 수정

```java
@PostMapping("/refresh")
public ResponseEntity<BaseResponse<LoginResponse>> refreshToken(
    @CookieValue(value = "refresh_token", required = false) String refreshToken,
    @RequestBody(required = false) Map<String, String> refreshTokenFromBody,
    HttpServletResponse response
) {
    // ...

    String token = refreshToken;

    // jwt.use-cookie=false 설정일 때는 요청 본문에서 리프레시 토큰 추출
    if ((token == null || token.isEmpty()) && refreshTokenFromBody != null) {
        token = refreshTokenFromBody.get("refreshToken");
    }

    // ...
}
```

### 6. `SecurityConfig.java` 수정
- CORS 설정에서 `jwt.use-cookie` 설정값에 따라 `allowCredentials` 설정을 다르게 적용
- 프로필 체크 로직 제거하고 설정값만으로 판단하도록 단순화

```java
@Configuration
@EnableWebSecurity
@RequiredArgsConstructor
public class SecurityConfig {

    @Value("${jwt.use-cookie:true}")
    private boolean useCookie;

    @Bean
    public CorsConfigurationSource corsConfigurationSource() {
        CorsConfiguration config = new CorsConfiguration();
        // 기존 설정...

        // jwt.use-cookie 설정에 따라 credentials 설정 변경
        config.setAllowCredentials(useCookie);

        // 기존 설정...
    }
}
```

## 동작 방식

### jwt.use-cookie=false 설정 (HTTP 환경)
1. 로그인/토큰 재발급 시 리프레시 토큰을 JSON 응답 본문에 포함하여 전달
2. 클라이언트는 리프레시 토큰을 로컬 스토리지나 메모리에 저장
3. 토큰 재발급 요청 시 리프레시 토큰을 요청 본문에 포함하여 전송
4. CORS 설정에서 `allowCredentials=false`로 설정되어 쿠키를 사용하지 않음

### jwt.use-cookie=true 설정 (HTTPS 환경)
1. 로그인/토큰 재발급 시 리프레시 토큰을 HTTP-Only 쿠키로 전달
2. 쿠키는 `Secure=true`, `SameSite=None` 속성으로 설정되어 HTTPS에서만 전송
3. 토큰 재발급 요청 시 쿠키가 자동으로 전송됨
4. CORS 설정에서 `allowCredentials=true`로 설정되어 쿠키를 사용함

## 결론
이 변경을 통해 JWT 토큰 전달 방식을 프로필 체크 없이 `jwt.use-cookie` 설정값만으로 결정하도록 단순화. HTTP 환경에서는 쿠키를 사용하지 않고 JSON 응답으로 토큰을 전달하고, HTTPS 환경에서는 쿠키를 사용하여 토큰을 전달하게 변경. 

## 스크린샷

## 주의사항

Closes #{이슈 번호}
