### PR TITLE
refactor: blacklist 엔티티의 jti에 인덱스를 건다.

### DIFF
--- a/src/main/java/sevenstar/marineleisure/global/jwt/BlacklistedRefreshToken.java
+++ b/src/main/java/sevenstar/marineleisure/global/jwt/BlacklistedRefreshToken.java
@@ -9,7 +9,10 @@ import sevenstar.marineleisure.global.domain.BaseEntity;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "blacklisted_refresh_tokens")
+@Table(name = "blacklisted_refresh_tokens", 
+       indexes = {
+           @Index(name = "idx_blacklisted_refresh_tokens_jti", columnList = "jti")
+       })
 @Getter
 @NoArgsConstructor
 public class BlacklistedRefreshToken extends BaseEntity {


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 기존에 redis를 통해서 먼저 검사하니 인덱스를 추가 안해도 크게 상관 없을 것으로 판단.
- 하지만 redis cloud 무료 플랜은 디스크 영속화가 꺼져 있기 때문에 인스턴스 재시작 되면 메모리 휘발.
- 따라서 엔티티의 jti 필드에 index 를 걸어 b-tree로 빠르게 검색할 수 있게 수정. 

구분 | 현상 | 영향
-- | -- | --
SELECT / EXISTS | 전 테이블 풀 스캔(blacklisted_refresh_tokens의 모든 행을 끝까지 읽어 jti = ? 조건을 비교) | 데이터가 수천 건일 때는 눈에 띄지 않지만, 수십만 건 이상이면 요청마다 수 ~ 수십 ms → 수백 ms까지 지연 예상
DELETE … WHERE expiryDate < NOW() | 마찬가지로 풀 스캔 → 오래‑걸리는 삭제 쿼리 동안 테이블‑락(or 레코드‑락) 보유 | API 쓰기 경합 시 락 대기 증가, 레이턴시·타임아웃 위험 예상
CPU·I/O 사용량 | 자주 호출되면 인덱스 없는 테이블 스캔이 RDS CPU 크레딧·I/O 크레딧을 빠르게 소모 |
커넥션 풀 고갈 | 블랙리스트 체크는 로그인·API 호출마다 수행 → 느린 쿼리가 쌓이면 커넥션이 대기열에 묶임 | “HikariPool – Connection is not available” 오류 위험

###변경 사항
'''java
@Table(
    indexes = @Index(name = "idx_blacklisted_refresh_tokens_jti", columnList = "jti")
)
'''
## 스크린샷

## 주의사항

Closes #{이슈 번호}
