### PR TITLE
feat: 회원 탈퇴 시 카카오 연결 끊기도 수행하게 구현한다.

### DIFF
--- a/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/MemberService.java
@@ -34,6 +34,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final MeetingRepository meetingRepository;
 	private final ParticipantRepository participantRepository;
+	private final OauthService oauthService;
 
 	/**
 	 * 회원 ID로 회원 상세 정보를 조회합니다.
@@ -188,7 +189,19 @@ public class MemberService {
 			participantRepository.deleteAll(participations);
 		}
 
-		// 3. 회원 상태를 EXPIRED로 변경 (실제 삭제 대신 소프트 삭제 방식 사용)
+		// 3. 카카오 계정 연결 끊기 (providerId가 있는 경우)
+		if (member.getProvider() != null && "kakao".equals(member.getProvider()) && member.getProviderId() != null) {
+			try {
+				oauthService.unlinkKakaoAccount(member.getProviderId());
+				log.info("카카오 계정 연결 끊기 성공: memberId={}, providerId={}", memberId, member.getProviderId());
+			} catch (Exception e) {
+				log.error("카카오 계정 연결 끊기 실패: memberId={}, providerId={}, error={}",
+					memberId, member.getProviderId(), e.getMessage(), e);
+				// 연결 끊기 실패 해도 탈퇴는 계속 진행
+			}
+		}
+
+		// 4. 회원 상태를 EXPIRED로 변경 (실제 삭제 대신 소프트 삭제 방식 사용)
 		updateMemberStatusField(member, MemberStatus.EXPIRED);
 		memberRepository.save(member);
 
@@ -206,6 +219,7 @@ public class MemberService {
 			log.error("[Scheduler] failed to delete expired member: {}", e.getMessage());
 		}
 	}
+
 	/**
 	 * 회원의 위치 정보를 업데이트합니다.
 	 * 이 메서드는 Member 엔티티의 updateLocation 메서드를 사용합니다.

--- a/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
@@ -277,4 +277,66 @@ class OauthServiceTest {
 		// verify
 		verify(memberRepository).findById(memberId);
 	}
+
+	@Test
+	@DisplayName("카카오 계정 연결 끊기를 요청할 수 있다")
+	void unlinkKakaoAccount() {
+		// given
+		String providerId = "12345";
+		Map<String, Object> response = new HashMap<>();
+		response.put("id", 12345L);
+
+		// WebClient 모킹
+		WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+		WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+		WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+		WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+		when(webClient.post()).thenReturn(requestBodyUriSpec);
+		when(requestBodyUriSpec.uri(eq("https://kapi.kakao.com/v1/user/unlink"))).thenReturn(requestBodySpec);
+		when(requestBodySpec.header(eq("Authorization"), eq("KakaoAK test-client-secret"))).thenReturn(requestBodySpec);
+		when(requestBodySpec.header(eq("Content-Type"), eq("application/x-www-form-urlencoded;charset=utf-8"))).thenReturn(requestBodySpec);
+		when(requestBodySpec.body(any())).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToMono(any(ParameterizedTypeReference.class))).thenReturn(Mono.just(response));
+
+		// when
+		Long result = oauthService.unlinkKakaoAccount(providerId);
+
+		// then
+		assertThat(result).isEqualTo(12345L);
+
+		// verify
+		verify(webClient).post();
+	}
+
+	@Test
+	@DisplayName("카카오 계정 연결 끊기 실패 시 예외가 발생한다")
+	void unlinkKakaoAccountFailed() {
+		// given
+		String providerId = "12345";
+		Map<String, Object> response = new HashMap<>();
+		// id 필드가 없는 응답
+
+		// WebClient 모킹
+		WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+		WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+		WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+		WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+		when(webClient.post()).thenReturn(requestBodyUriSpec);
+		when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+		when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
+		when(requestBodySpec.body(any())).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		when(responseSpec.bodyToMono(any(ParameterizedTypeReference.class))).thenReturn(Mono.just(response));
+
+		// when & then
+		assertThatThrownBy(() -> oauthService.unlinkKakaoAccount(providerId))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("Failed to unlink Kakao account");
+
+		// verify
+		verify(webClient).post();
+	}
 }


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
### 변경 사항 요약
회원 탈퇴 시 카카오 계정과의 연결을 끊는 기능을 구현했습니다. 이 기능은 사용자가 서비스를 탈퇴할 때 카카오 API를 통해 앱과 카카오 계정의 연결을 해제합니다. 카카오 공식 문서에서도 이를 권장하고 있어 구현하게 되었습니다.

### 변경 사유
1. **개인정보 보호**: 사용자가 서비스를 탈퇴할 때 카카오 계정과의 연결을 끊어 개인정보 보호를 강화
2. **사용자 경험 개선**: 사용자가 서비스를 탈퇴한 후에도 카카오 계정과 앱의 연결이 유지되면 사용자 입장에서 예상치 못한 상황이 된다.
3. **카카오 API 정책 준수**: 카카오 API 정책에 따라 사용자가 서비스를 탈퇴할 때 연결을 끊는 것이 권장
4. **소프트 딜리트와 연계**: 현재 구현된 소프트 딜리트(EXPIRED 상태로 변경)와 함께 카카오 연결 끊기를 구현하여 완전한 회원 탈퇴 프로세스를 제공하게 된다.

### 고민한 점

> **unlink 메서드가 하드 딜리트 시에 실행 되는게 맞을까 아니면 소프트 딜리트 시점에 실행 되는게 맞을까?**  

### 현재 구현 상태
결론적으로 현재 코드에서는 회원 탈퇴 처리 시 다음과 같은 프로세스로 구현했다

1. **소프트 딜리트 단계**:
   - `MemberService.deleteMember()` 메서드에서 회원 상태를 `EXPIRED`로 변경
   - 이 단계에서 카카오 계정 연결 끊기(`oauthService.unlinkKakaoAccount()`)가 실행됨
   - 연결 끊기에 실패하더라도 회원 탈퇴 처리는 계속 진행됨

2. **하드 딜리트 단계**:
   - `MemberService.deleteExpiredMember()` 스케줄러 메서드에서 30일이 지난 `EXPIRED` 상태의 회원을 영구 삭제
   - 이 단계에서는 카카오 연결 끊기를 수행하지 않음

### 소프트 딜리트 vs 하드 딜리트 시 연결 끊기 비교

### 소프트 딜리트 시 연결 끊기 (현재 구현)
**장점:**
1. 사용자의 탈퇴 요청에 즉시 응답하여 카카오 계정과의 연결을 끊음
2. 30일 유예 기간 동안 사용자가 카카오 연결 앱 목록에서 앱을 보지 않게 됨 (사용자가 예상치 못한 상황 방지)
3. 사용자 기대에 부합 - 탈퇴 시 모든 연결이 즉시 제거될 것으로 기대함
4. 즉시 접근 권한을 취소하여 보안성 강화
5. 최소 권한 원칙 준수 - 필요 이상으로 연결을 유지하지 않음

**단점:**
1. 30일 유예 기간 내 계정 복구 시 카카오 재연결 필요
2. 사용자가 30일 내에 계정을 복구하는 경우 추가 API 호출 발생

### 하드 딜리트 시 연결 끊기 (대안)
**장점:**
1. 30일 유예 기간 동안 동일한 카카오 연결로 계정 복구 가능성 유지
2. 사용자가 30일 내에 계정을 복구하는 경우 API 호출 감소

**단점:**
1. 하드 딜리트 시점에는 이미 회원 정보가 삭제되어 providerId에 접근할 수 없음
2. 별도의 저장 메커니즘을 구현해야 하는 추가 복잡성 발생
3. 사용자가 탈퇴했음에도 30일 동안 앱과 카카오 계정의 연결이 유지되어 혼란 가능성 -> 가장 중요하다고 생각한 포인트
4. 보안 관점에서 불필요하게 오랜 기간 연결 유지

## 결론

**소프트 딜리트 시점에 카카오 계정 연결을 끊는 것**이 더 적절하다고 판단해서 해당 방식으로 구현했다..

1. **사용자 경험**: 사용자가 탈퇴를 요청했을 때 모든 연결이 즉시 끊어질 것으로 기대함
2. **보안 관점**: 사용자 요청 시 즉시 연결을 끊는 것이 보안 관점에서 적절함
3. **개인정보 보호 관점**: 사용자 요청 시 즉시 제3자 연결을 제거하는 것이 개인정보 보호 규정 준수에 도움
4. **구현된 하드 delete 관점**: 하드 딜리트 시점에는 회원 정보가 이미 삭제되어 providerId에 접근할 수 없음
5. **복구 메커니즘**: 30일 내 계정 복구 시 사용자는 카카오로 다시 로그인하여 새 연결 생성 가능

## 스크린샷

## 주의사항

Closes #97 