### PR TITLE
feat: 카카오 로그인 과정에서 pkce를 통해 보안 관점에서 개선

### DIFF
--- a/src/main/java/sevenstar/marineleisure/global/api/scheduler/SchedulerService.java
+++ b/src/main/java/sevenstar/marineleisure/global/api/scheduler/SchedulerService.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +17,6 @@ import sevenstar.marineleisure.global.api.openmeteo.dto.service.OpenMeteoService
 import sevenstar.marineleisure.spot.repository.SpotViewQuartileRepository;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class SchedulerService {
 	public static final int MAX_UPDATE_DAY = 3;
@@ -23,8 +24,23 @@ public class SchedulerService {
 	private final OpenMeteoService openMeteoService;
 	private final PresetSchedulerService presetSchedulerService;
 	private final SpotViewQuartileRepository spotViewQuartileRepository;
+
+
 	private final Executor taskExecutor;
 
+	public SchedulerService(
+		KhoaApiService khoaApiService,
+		OpenMeteoService openMeteoService,
+		PresetSchedulerService presetSchedulerService,
+		SpotViewQuartileRepository spotViewQuartileRepository,
+		@Qualifier("applicationTaskExecutor") Executor taskExecutor   // ★ 여기
+	) {
+		this.khoaApiService          = khoaApiService;
+		this.openMeteoService        = openMeteoService;
+		this.presetSchedulerService  = presetSchedulerService;
+		this.spotViewQuartileRepository = spotViewQuartileRepository;
+		this.taskExecutor            = taskExecutor;
+	}
 	/**
 	 * 앞으로의 스케줄링 전략에 의해 수정될 부분입니다.
 	 * @author guwnoong

--- a/src/main/java/sevenstar/marineleisure/global/util/PkceUtil.java
+++ b/src/main/java/sevenstar/marineleisure/global/util/PkceUtil.java
@@ -1,0 +1,31 @@
+package sevenstar.marineleisure.global.util;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PkceUtil {
+	public String generateCodeVerifier() {
+		SecureRandom random = new SecureRandom();
+		byte[] bytes = new byte[64];
+		random.nextBytes(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
+	public String generateCodeChallenge(String codeVerifier) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] bytes = digest.digest(codeVerifier.getBytes());
+			return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to generate code challenge", e);
+		}
+	}
+
+	public boolean verifyCodeChallenge(String codeChallenge, String codeVerifier) {
+		return false;
+	}
+}

--- a/src/main/java/sevenstar/marineleisure/global/util/StateEncryptionUtil.java
+++ b/src/main/java/sevenstar/marineleisure/global/util/StateEncryptionUtil.java
@@ -27,33 +27,18 @@ public class StateEncryptionUtil {
      * @param state 암호화할 상태 값
      * @return 암호화된 상태 값 (Base64 인코딩)
      */
-    public String encryptState(String state, String codeVerifier) {
+    public String encryptState(String state) {
         try {
-            String combined = state + "|" + codeVerifier;
-
             SecretKeySpec keySpec = generateKey(secretKey);
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
             cipher.init(Cipher.ENCRYPT_MODE, keySpec);
-            byte[] encrypted = cipher.doFinal(combined.getBytes(StandardCharsets.UTF_8));
+            byte[] encrypted = cipher.doFinal(state.getBytes(StandardCharsets.UTF_8));
             return Base64.getUrlEncoder().encodeToString(encrypted);
         } catch (Exception e) {
             throw new RuntimeException("Failed to encrypt state", e);
         }
     }
 
-
-    public String extractCodeVerifier(String state) {
-		try {
-			String decrypted = decryptState(state);
-			String[] parts = decrypted.split("\\|", 2);
-			if (parts.length != 2) {
-				throw new IllegalArgumentException("Invalid encrypted format");
-			}
-            return parts[1];
-		} catch (IllegalArgumentException e) {
-			throw new RuntimeException("Failed to extract code verifier", e);
-		}
-	}
 
     /**
      * 암호화된 상태 값을 복호화.
@@ -83,12 +68,7 @@ public class StateEncryptionUtil {
      */
     public boolean validateState(String state, String encryptedState) {
         try {
-            String decryptedState = decryptState(encryptedState);
-            String[] parts = decryptedState.split("\\|", 2);
-            if (parts.length != 2) {
-                return false;
-            }
-            return parts[0].equals(state);
+            return decryptState(encryptedState).equals(state);
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
+++ b/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
@@ -47,10 +47,11 @@ public class AuthController {
 	@GetMapping("/kakao/url")
 	public ResponseEntity<BaseResponse<Map<String, String>>> getKakaoLoginUrl(
 		@RequestParam(required = false) String redirectUri,
+		@RequestParam String codeChallenge,
 		HttpServletRequest request
 	) {
 		log.info("Generating Kakao login URL with redirectUri: {}", redirectUri);
-		Map<String, String> loginUrlInfo = oauthService.getKakaoLoginUrl(redirectUri, request);
+		Map<String, String> loginUrlInfo = oauthService.getKakaoLoginUrl(redirectUri, codeChallenge ,request);
 		return BaseResponse.success(loginUrlInfo);
 	}
 

--- a/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
+++ b/src/main/java/sevenstar/marineleisure/member/controller/AuthController.java
@@ -87,6 +87,7 @@ public class AuthController {
 				request.code(),
 				request.state(),
 				request.encryptedState(),
+				request.codeVerifier(),
 				response
 			);
 			return BaseResponse.success(loginResponse);

--- a/src/main/java/sevenstar/marineleisure/member/dto/AuthCodeRequest.java
+++ b/src/main/java/sevenstar/marineleisure/member/dto/AuthCodeRequest.java
@@ -13,6 +13,7 @@ public record AuthCodeRequest(
 	String code,
 	String state,
 	String encryptedState,
+	String codeVerifier,
 	String error,
 	String errorDescription
 ) {

--- a/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
@@ -1,15 +1,12 @@
 package sevenstar.marineleisure.member.service;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.data.redis.connection.StringRedisConnection;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -56,16 +53,18 @@ public class OauthService {
 	 * @param customRedirectUri 커스텀 리다이렉트 URI (null인 경우 기본값 사용)
 	 * @return 카카오 로그인 URL, state 값, 암호화된 state 값을 포함한 Map
 	 */
-	public Map<String, String> getKakaoLoginUrl(String customRedirectUri) {
+	public Map<String, String> getKakaoLoginUrl(String customRedirectUri, String codeChallenge) {
 
 		String state = UUID.randomUUID().toString();
-		String codeVerifier = pkceUtil.generateCodeVerifier();
-		String codeChallenge = pkceUtil.generateCodeChallenge(codeVerifier);
+
+		/// 기존 서버에서 codeVerifier 생성하는 코드 흐름
+		// String codeVerifier = pkceUtil.generateCodeVerifier();
+		// String codeChallenge = pkceUtil.generateCodeChallenge(codeVerifier);
 
 		String encryptedState = stateEncryptionUtil.encryptState(state);
 
 		log.info("Generated OAuth state: {} (encrypted: {})", state, encryptedState);
-		log.info("Generated PKCE code_verifier: {} (challenge: {})", codeVerifier, codeChallenge);
+		// log.info("Generated PKCE code_verifier: {} (challenge: {})", codeVerifier, codeChallenge);
 
 		// Use the provided redirectUri or fall back to the configured one
 		String finalRedirectUri = customRedirectUri != null ? customRedirectUri : this.redirectUri;
@@ -84,8 +83,8 @@ public class OauthService {
 		return Map.of(
 			"kakaoAuthUrl", kakaoAuthUrl,
 			"state", state,
-			"encryptedState", encryptedState,
-			"codeVerifier", codeVerifier // 추가.
+			"encryptedState", encryptedState
+			// "codeVerifier", codeVerifier // 추가.
 		);
 	}
 
@@ -96,9 +95,9 @@ public class OauthService {
 	 * @param request HTTP 요청 (호환성을 위해 유지, 사용하지 않음)
 	 * @return 카카오 로그인 URL, state 값, 암호화된 state 값을 포함한 Map
 	 */
-	public Map<String, String> getKakaoLoginUrl(String customRedirectUri, HttpServletRequest request) {
+	public Map<String, String> getKakaoLoginUrl(String customRedirectUri,String codeChallenge ,HttpServletRequest request) {
 		// 세션 사용하지 않고 stateless 방식으로 구현
-		return getKakaoLoginUrl(customRedirectUri);
+		return getKakaoLoginUrl(customRedirectUri, codeChallenge);
 	}
 
 	/**

--- a/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
+++ b/src/main/java/sevenstar/marineleisure/member/service/OauthService.java
@@ -1,12 +1,15 @@
 package sevenstar.marineleisure.member.service;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -54,12 +57,12 @@ public class OauthService {
 	 * @return 카카오 로그인 URL, state 값, 암호화된 state 값을 포함한 Map
 	 */
 	public Map<String, String> getKakaoLoginUrl(String customRedirectUri) {
-		String state = UUID.randomUUID().toString();
 
+		String state = UUID.randomUUID().toString();
 		String codeVerifier = pkceUtil.generateCodeVerifier();
 		String codeChallenge = pkceUtil.generateCodeChallenge(codeVerifier);
 
-		String encryptedState = stateEncryptionUtil.encryptState(state, codeVerifier);
+		String encryptedState = stateEncryptionUtil.encryptState(state);
 
 		log.info("Generated OAuth state: {} (encrypted: {})", state, encryptedState);
 		log.info("Generated PKCE code_verifier: {} (challenge: {})", codeVerifier, codeChallenge);
@@ -81,7 +84,8 @@ public class OauthService {
 		return Map.of(
 			"kakaoAuthUrl", kakaoAuthUrl,
 			"state", state,
-			"encryptedState", encryptedState
+			"encryptedState", encryptedState,
+			"codeVerifier", codeVerifier // 추가.
 		);
 	}
 

--- a/src/test/java/sevenstar/marineleisure/member/controller/AuthControllerTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/controller/AuthControllerTest.java
@@ -76,14 +76,17 @@ class AuthControllerTest {
 		loginUrlInfo.put("kakaoAuthUrl",
 			"https://kauth.kakao.com/oauth/authorize?client_id=test-api-key"
 				+ "&redirect_uri=http://localhost:8080/oauth/kakao/code"
-				+ "&response_type=code&state=test-state");
+				+ "&response_type=code&state=test-state"
+				+ "&code_challenge=test-code-challenge"
+				+ "&code_challenge_method=S256");
 		loginUrlInfo.put("state", "test-state");
 		loginUrlInfo.put("encryptedState", "encrypted-test-state");
 		loginUrlInfo.put("accessToken", "test-access-token");
 
-		when(oauthService.getKakaoLoginUrl(isNull(), any())).thenReturn(loginUrlInfo);
+		when(oauthService.getKakaoLoginUrl(isNull(), eq("test-code-challenge"), any())).thenReturn(loginUrlInfo);
 
-		mockMvc.perform(get("/auth/kakao/url"))
+		mockMvc.perform(get("/auth/kakao/url")
+				.param("codeChallenge", "test-code-challenge"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value(200))
 			.andExpect(jsonPath("$.body.kakaoAuthUrl").exists())
@@ -100,14 +103,18 @@ class AuthControllerTest {
 		loginUrlInfo.put("kakaoAuthUrl",
 			"https://kauth.kakao.com/oauth/authorize?client_id=test-api-key"
 				+ "&redirect_uri=" + customRedirectUri
-				+ "&response_type=code&state=test-state");
+				+ "&response_type=code&state=test-state"
+				+ "&code_challenge=test-code-challenge"
+				+ "&code_challenge_method=S256");
 		loginUrlInfo.put("state", "test-state");
 		loginUrlInfo.put("encryptedState", "encrypted-test-state");
 		loginUrlInfo.put("accessToken", "test-access-token");
 
-		when(oauthService.getKakaoLoginUrl(any(), any())).thenReturn(loginUrlInfo);
+		when(oauthService.getKakaoLoginUrl(eq(customRedirectUri), eq("test-code-challenge"), any())).thenReturn(loginUrlInfo);
 
-		mockMvc.perform(get("/auth/kakao/url").param("redirectUri", customRedirectUri))
+		mockMvc.perform(get("/auth/kakao/url")
+				.param("redirectUri", customRedirectUri)
+				.param("codeChallenge", "test-code-challenge"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value(200))
 			.andExpect(jsonPath("$.body.kakaoAuthUrl").exists())

--- a/src/test/java/sevenstar/marineleisure/member/controller/AuthControllerTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/controller/AuthControllerTest.java
@@ -119,9 +119,9 @@ class AuthControllerTest {
 	@Test
 	@DisplayName("카카오 로그인을 처리할 수 있다 (쿠키 모드)")
 	void kakaoLogin() throws Exception {
-		AuthCodeRequest request = new AuthCodeRequest("test-auth-code", "test-state", "encrypted-test-state", null,
+		AuthCodeRequest request = new AuthCodeRequest("test-auth-code", "test-state", "encrypted-test-state", "test-code-verifier", null,
 			null);
-		when(authService.processKakaoLogin(eq("test-auth-code"), eq("test-state"), eq("encrypted-test-state"), any(
+		when(authService.processKakaoLogin(eq("test-auth-code"), eq("test-state"), eq("encrypted-test-state"), eq("test-code-verifier"), any(
 			HttpServletResponse.class))).thenReturn(loginResponseCookie);
 
 		mockMvc.perform(post("/auth/kakao/code")
@@ -139,9 +139,9 @@ class AuthControllerTest {
 	@Test
 	@DisplayName("카카오 로그인을 처리할 수 있다 (비쿠키 모드)")
 	void kakaoLogin_noCookie() throws Exception {
-		AuthCodeRequest request = new AuthCodeRequest("test-auth-code", "test-state", "encrypted-test-state", null,
+		AuthCodeRequest request = new AuthCodeRequest("test-auth-code", "test-state", "encrypted-test-state", "test-code-verifier", null,
 			null);
-		when(authService.processKakaoLogin(eq("test-auth-code"), eq("test-state"), eq("encrypted-test-state"), any(
+		when(authService.processKakaoLogin(eq("test-auth-code"), eq("test-state"), eq("encrypted-test-state"), eq("test-code-verifier"), any(
 			HttpServletResponse.class))).thenReturn(loginResponseNoCookie);
 
 		mockMvc.perform(post("/auth/kakao/code")
@@ -159,8 +159,8 @@ class AuthControllerTest {
 	@Test
 	@DisplayName("카카오 로그인 처리 중 오류가 발생하면 에러 응답을 반환한다")
 	void kakaoLogin_error() throws Exception {
-		AuthCodeRequest request = new AuthCodeRequest("invalid-code", "test-state", "encrypted-test-state", null, null);
-		when(authService.processKakaoLogin(eq("invalid-code"), eq("test-state"), eq("encrypted-test-state"),
+		AuthCodeRequest request = new AuthCodeRequest("invalid-code", "test-state", "encrypted-test-state", "test-code-verifier", null, null);
+		when(authService.processKakaoLogin(eq("invalid-code"), eq("test-state"), eq("encrypted-test-state"), eq("test-code-verifier"),
 			any(HttpServletResponse.class)))
 			.thenThrow(new RuntimeException("Failed to get access token from Kakao"));
 
@@ -175,7 +175,7 @@ class AuthControllerTest {
 	@Test
 	@DisplayName("사용자가 카카오 로그인을 취소하면 취소 응답을 반환한다")
 	void kakaoLogin_canceled() throws Exception {
-		AuthCodeRequest request = new AuthCodeRequest(null, "test-state", "encrypted-test-state", "access_denied",
+		AuthCodeRequest request = new AuthCodeRequest(null, "test-state", "encrypted-test-state", null, "access_denied",
 			"User denied access");
 
 		mockMvc.perform(post("/auth/kakao/code")
@@ -189,7 +189,7 @@ class AuthControllerTest {
 	@Test
 	@DisplayName("카카오 로그인 중 다른 에러가 발생하면 에러 응답을 반환한다")
 	void kakaoLogin_otherError() throws Exception {
-		AuthCodeRequest request = new AuthCodeRequest(null, "test-state", "encrypted-test-state", "server_error",
+		AuthCodeRequest request = new AuthCodeRequest(null, "test-state", "encrypted-test-state", null, "server_error",
 			"Internal server error");
 
 		mockMvc.perform(post("/auth/kakao/code")

--- a/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
@@ -77,6 +77,7 @@ class AuthServiceTest {
 		String accessToken = "kakao-access-token";
 		String jwtAccessToken = "jwt-access-token";
 		String refreshToken = "jwt-refresh-token";
+		String codeVerifier = "test-code-verifier";
 
 		// useCookie = true 설정 (기본값)
 		ReflectionTestUtils.setField(authService, "useCookie", true);
@@ -103,7 +104,7 @@ class AuthServiceTest {
 		when(jwtTokenProvider.createRefreshToken(testMember)).thenReturn(refreshToken);
 
 		// when
-		LoginResponse response = authService.processKakaoLogin(code, state, encryptedState, mockResponse);
+		LoginResponse response = authService.processKakaoLogin(code, state, encryptedState, codeVerifier, mockResponse);
 
 		// then
 		assertThat(response).isNotNull();
@@ -127,6 +128,7 @@ class AuthServiceTest {
 		String accessToken = "kakao-access-token";
 		String jwtAccessToken = "jwt-access-token";
 		String refreshToken = "jwt-refresh-token";
+		String codeVerifier = "test-code-verifier";
 
 		// useCookie = false 설정
 		ReflectionTestUtils.setField(authService, "useCookie", false);
@@ -149,7 +151,7 @@ class AuthServiceTest {
 		when(jwtTokenProvider.createRefreshToken(testMember)).thenReturn(refreshToken);
 
 		// when
-		LoginResponse response = authService.processKakaoLogin(code, state, encryptedState, mockResponse);
+		LoginResponse response = authService.processKakaoLogin(code, state, encryptedState, codeVerifier, mockResponse);
 
 		// then
 		assertThat(response).isNotNull();
@@ -170,6 +172,7 @@ class AuthServiceTest {
 		String code = "test-auth-code";
 		String state = "test-state";
 		String encryptedState = "encrypted-test-state";
+		String codeVerifier = "test-code-verifier";
 
 		// 액세스 토큰이 없는 응답 설정
 		KakaoTokenResponse tokenResponse = KakaoTokenResponse.builder()
@@ -185,7 +188,7 @@ class AuthServiceTest {
 		when(oauthService.exchangeCodeForToken(code, codeVerifier)).thenReturn(tokenResponse);
 
 		// when & then
-		assertThatThrownBy(() -> authService.processKakaoLogin(code, state, encryptedState, mockResponse))
+		assertThatThrownBy(() -> authService.processKakaoLogin(code, state, encryptedState, codeVerifier, mockResponse))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessageContaining("Failed to get access token from Kakao");
 	}

--- a/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/AuthServiceTest.java
@@ -96,7 +96,7 @@ class AuthServiceTest {
 		when(stateEncryptionUtil.validateState(state, encryptedState)).thenReturn(true);
 
 		// 서비스 메서드 모킹
-		when(oauthService.exchangeCodeForToken(code)).thenReturn(tokenResponse);
+		when(oauthService.exchangeCodeForToken(code, codeVerifier)).thenReturn(tokenResponse);
 		when(oauthService.processKakaoUser(accessToken)).thenReturn(testMember);
 		// findUserById는 이제 필요 없음 (processKakaoUser가 직접 Member를 반환)
 		when(jwtTokenProvider.createAccessToken(testMember)).thenReturn(jwtAccessToken);
@@ -143,7 +143,7 @@ class AuthServiceTest {
 		when(stateEncryptionUtil.validateState(state, encryptedState)).thenReturn(true);
 
 		// 서비스 메서드 모킹
-		when(oauthService.exchangeCodeForToken(code)).thenReturn(tokenResponse);
+		when(oauthService.exchangeCodeForToken(code, codeVerifier)).thenReturn(tokenResponse);
 		when(oauthService.processKakaoUser(accessToken)).thenReturn(testMember);
 		when(jwtTokenProvider.createAccessToken(testMember)).thenReturn(jwtAccessToken);
 		when(jwtTokenProvider.createRefreshToken(testMember)).thenReturn(refreshToken);
@@ -182,7 +182,7 @@ class AuthServiceTest {
 		// state 검증 모킹
 		when(stateEncryptionUtil.validateState(state, encryptedState)).thenReturn(true);
 
-		when(oauthService.exchangeCodeForToken(code)).thenReturn(tokenResponse);
+		when(oauthService.exchangeCodeForToken(code, codeVerifier)).thenReturn(tokenResponse);
 
 		// when & then
 		assertThatThrownBy(() -> authService.processKakaoLogin(code, state, encryptedState, mockResponse))

--- a/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
@@ -119,7 +119,7 @@ class OauthServiceTest {
 		when(responseSpec.bodyToMono(KakaoTokenResponse.class)).thenReturn(Mono.just(expectedResponse));
 
 		// when
-		KakaoTokenResponse result = oauthService.exchangeCodeForToken(code);
+		KakaoTokenResponse result = oauthService.exchangeCodeForToken(code, codeVerifier);
 
 		// then
 		assertThat(result).isNotNull();

--- a/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
@@ -3,7 +3,6 @@ package sevenstar.marineleisure.member.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,15 +66,13 @@ class OauthServiceTest {
 	@DisplayName("카카오 로그인 URL을 생성할 수 있다")
 	void getKakaoLoginUrl() {
 		// when
-		Map<String, String> result = oauthService.getKakaoLoginUrl(null);
+		Map<String, String> result = oauthService.getKakaoLoginUrl(null, "test-code-challenge");
 
 		// then
 		assertThat(result).containsKey("kakaoAuthUrl");
 		assertThat(result).containsKey("state");
 		assertThat(result).containsKey("encryptedState");
-		assertThat(result).containsKey("codeVerifier");
 		assertThat(result.get("encryptedState")).isEqualTo("encrypted-state");
-		assertThat(result.get("codeVerifier")).isEqualTo("test-code-verifier");
 		assertThat(result.get("kakaoAuthUrl")).contains("https://kauth.kakao.com/oauth/authorize");
 		assertThat(result.get("kakaoAuthUrl")).contains("client_id=test-api-key");
 		assertThat(result.get("kakaoAuthUrl")).contains("redirect_uri=http://localhost:8080/oauth/kakao/code");
@@ -92,15 +89,13 @@ class OauthServiceTest {
 		String customRedirectUri = "http://custom-redirect.com/callback";
 
 		// when
-		Map<String, String> result = oauthService.getKakaoLoginUrl(customRedirectUri);
+		Map<String, String> result = oauthService.getKakaoLoginUrl(customRedirectUri, "test-code-challenge");
 
 		// then
 		assertThat(result).containsKey("kakaoAuthUrl");
 		assertThat(result).containsKey("state");
 		assertThat(result).containsKey("encryptedState");
-		assertThat(result).containsKey("codeVerifier");
 		assertThat(result.get("encryptedState")).isEqualTo("encrypted-state");
-		assertThat(result.get("codeVerifier")).isEqualTo("test-code-verifier");
 		assertThat(result.get("kakaoAuthUrl")).contains("redirect_uri=" + customRedirectUri);
 		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge=test-code-challenge");
 		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge_method=S256");

--- a/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
+++ b/src/test/java/sevenstar/marineleisure/member/service/OauthServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import reactor.core.publisher.Mono;
+import sevenstar.marineleisure.global.util.PkceUtil;
 import sevenstar.marineleisure.global.util.StateEncryptionUtil;
 import sevenstar.marineleisure.member.domain.Member;
 import sevenstar.marineleisure.member.dto.KakaoTokenResponse;
@@ -39,6 +40,9 @@ class OauthServiceTest {
 	@Mock
 	private StateEncryptionUtil stateEncryptionUtil;
 
+	@Mock
+	private PkceUtil pkceUtil;
+
 	@InjectMocks
 	private OauthService oauthService;
 
@@ -53,6 +57,10 @@ class OauthServiceTest {
 		// StateEncryptionUtil 모킹 (lenient 설정으로 불필요한 stubbing 경고 방지)
 		lenient().when(stateEncryptionUtil.encryptState(anyString())).thenReturn("encrypted-state");
 		lenient().when(stateEncryptionUtil.validateState(anyString(), anyString())).thenReturn(true);
+
+		// PkceUtil 모킹
+		lenient().when(pkceUtil.generateCodeVerifier()).thenReturn("test-code-verifier");
+		lenient().when(pkceUtil.generateCodeChallenge(anyString())).thenReturn("test-code-challenge");
 	}
 
 	@Test
@@ -65,12 +73,16 @@ class OauthServiceTest {
 		assertThat(result).containsKey("kakaoAuthUrl");
 		assertThat(result).containsKey("state");
 		assertThat(result).containsKey("encryptedState");
+		assertThat(result).containsKey("codeVerifier");
 		assertThat(result.get("encryptedState")).isEqualTo("encrypted-state");
+		assertThat(result.get("codeVerifier")).isEqualTo("test-code-verifier");
 		assertThat(result.get("kakaoAuthUrl")).contains("https://kauth.kakao.com/oauth/authorize");
 		assertThat(result.get("kakaoAuthUrl")).contains("client_id=test-api-key");
 		assertThat(result.get("kakaoAuthUrl")).contains("redirect_uri=http://localhost:8080/oauth/kakao/code");
 		assertThat(result.get("kakaoAuthUrl")).contains("response_type=code");
 		assertThat(result.get("kakaoAuthUrl")).contains("state=" + result.get("state"));
+		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge=test-code-challenge");
+		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge_method=S256");
 	}
 
 	@Test
@@ -86,8 +98,12 @@ class OauthServiceTest {
 		assertThat(result).containsKey("kakaoAuthUrl");
 		assertThat(result).containsKey("state");
 		assertThat(result).containsKey("encryptedState");
+		assertThat(result).containsKey("codeVerifier");
 		assertThat(result.get("encryptedState")).isEqualTo("encrypted-state");
+		assertThat(result.get("codeVerifier")).isEqualTo("test-code-verifier");
 		assertThat(result.get("kakaoAuthUrl")).contains("redirect_uri=" + customRedirectUri);
+		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge=test-code-challenge");
+		assertThat(result.get("kakaoAuthUrl")).contains("code_challenge_method=S256");
 	}
 
 	@Test
@@ -95,6 +111,7 @@ class OauthServiceTest {
 	void exchangeCodeForToken() {
 		// given
 		String code = "test-auth-code";
+		String codeVerifier = "test-code-verifier";
 		KakaoTokenResponse expectedResponse = KakaoTokenResponse.builder()
 			.accessToken("test-access-token")
 			.tokenType("bearer")


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
## 기존 방식 -> OAuth 2.0에서의 State 파라미터

### 목적
State 파라미터는 주로 CSRF(Cross-Site Request Forgery) 공격을 방지하기 위해 사용됩니다. 이는 인증 요청과 콜백 사이의 상태를 유지하고, 콜백이 원래 요청한 클라이언트에서 온 것인지 확인하는 데 사용됩니다.

### 보안 이점
- CSRF 공격 방지: 공격자가 사용자를 속여 의도하지 않은 인증 요청을 하도록 할 수 없습니다.
- 세션 고정 공격 방지: 각 인증 요청마다 고유한 state 값을 사용하여 세션 고정 공격을 방지합니다.

### 취약점
- 인가 코드가 노출되면 공격자는 그대로 /token 교환 -> 토큰 탈취가 가능합니다
- redirect url를 탈취하면 state 값이 그대로 적혀 있기 때문에, 로그인이 가능해져 버립니다.
- 실제 테스트 해본 결과, url에서 state 와 code를 뽑아서 postman으로 로그인 요청을 보내면 로그인이 가능합니다.
## 새로 추가된 보안 사항: PKCE(Proof Key for Code Exchange)

### 목적
PKCE는 인증 코드 가로채기 공격을 방지하기 위해 설계되었습니다. 특히 모바일 앱이나 단일 페이지 애플리케이션(SPA)과 같은 공개 클라이언트에서 중요합니다. 

### 작동 방식
1. 클라이언트는 인증 요청을 시작할 때 code_verifier(랜덤 문자열)를 생성합니다.
2. 클라이언트는 code_verifier를 해시하여 code_challenge를 생성합니다.
3. code_challenge는 인증 요청 URL에 포함되어 인증 서버로 전송됩니다.
4. 사용자가 인증을 완료하고 인증 코드를 받으면, 클라이언트는 이 코드와 원래의 code_verifier를 함께 토큰 요청에 포함시킵니다.
5. 인증 서버는 받은 code_verifier를 해시하여 원래 받은 code_challenge와 비교합니다.

### 보안 이점
- 인증 코드 가로채기 공격 방지: 공격자가 인증 코드를 가로채더라도 code_verifier 없이는 토큰을 얻을 수 없습니다.  codeVerifier가 없으면 /token이 실패하게 됩니다.
- 리다이렉트 URI 조작 방지: 공격자가 리다이렉트 URI를 조작하여 인증 코드를 가로채는 것을 방지합니다. (카카오 서버에서 돌려주는 redirect url에서 state만 드러나기 때문에)
- 클라이언트에서 code_verifier와 code_challenge 쌍을 생성해서 이 접근 방식을 적용한다면, 공격자는 /auth/kakao/url 의 응답을 탈취한다고 한들, code_verifier를 절대 모르게 되어 xss 를 통한 탈취에서도 어느 정도 안전해지게 됩니다. 
- RFC 7636 — “code interception is a primary threat for public clients; PKCE SHALL be used with authorization‑code flow when client cannot keep a secret” 를 준수합니다.


## 스크린샷
### state 만 사용 (csrf만 방지 가능)
<img width="1136" height="915" alt="login시_state_콜백_state만" src="https://github.com/user-attachments/assets/a7c0a0c3-16f4-41bf-a42d-fe2a73bc55e6" />
<img width="1299" height="807" alt="state만_보안공격" src="https://github.com/user-attachments/assets/92bb7f90-7b2a-40d6-896a-4ff17eda4b63" />

### state + PKCE (csrf + redirect url 탈취 등 ...)
<img width="1125" height="913" alt="login시_state_콜백" src="https://github.com/user-attachments/assets
<img width="1539" height="946" alt="state+pkce" src="https://github.com/user-attachments/assets/5a8ab3f0-ca82-4022-8570-f511b7571b92" />
/ddfd36d2-f086-44dd-9dd7-b47825b1ae59" />

## 참고 문헌
- https://devocean.sk.com/blog/techBoardDetail.do?ID=166255&boardType=techBlog&utm_source=chatgpt.com
- rfc 7636 [https://oauth.net/2/pkce/]
## 주의사항

Closes #{이슈 번호}
