### PR TITLE
release (#126)

### DIFF
--- a/src/main/java/sevenstar/marineleisure/activity/service/ActivityService.java
+++ b/src/main/java/sevenstar/marineleisure/activity/service/ActivityService.java
@@ -29,7 +29,9 @@ import sevenstar.marineleisure.forecast.repository.SurfingRepository;
 import sevenstar.marineleisure.global.enums.ActivityCategory;
 import sevenstar.marineleisure.global.enums.TimePeriod;
 import sevenstar.marineleisure.spot.domain.OutdoorSpot;
+import sevenstar.marineleisure.spot.dto.SpotPreviewReadResponse;
 import sevenstar.marineleisure.spot.repository.OutdoorSpotRepository;
+import sevenstar.marineleisure.spot.service.SpotService;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +43,8 @@ public class ActivityService {
     private final MudflatRepository mudflatRepository;
     private final ScubaRepository scubaRepository;
     private final SurfingRepository surfingRepository;
+
+    private final SpotService spotService;
 
     @Transactional(readOnly = true)
     public Map<String, ActivitySummaryResponse> getActivitySummary(BigDecimal latitude, BigDecimal longitude,
@@ -55,72 +59,79 @@ public class ActivityService {
     private Map<String, ActivitySummaryResponse> getLocalActivitySummary(BigDecimal latitude, BigDecimal longitude) {
         Map<String, ActivitySummaryResponse> responses = new HashMap<>();
 
-        Fishing fishingBySpot = null;
-        Mudflat mudflatBySpot = null;
-        Surfing surfingBySpot = null;
-        Scuba scubaBySpot = null;
+        SpotPreviewReadResponse preview = spotService.preview(latitude.floatValue(), longitude.floatValue());
+        responses.put("Fishing",
+            new ActivitySummaryResponse(preview.fishing().getName(), preview.fishing().getTotalIndex()));
+        responses.put("Mudflat",new ActivitySummaryResponse(preview.mudflat().getName(), preview.mudflat().getTotalIndex()));
+        responses.put("Surfing", new ActivitySummaryResponse(preview.surfing().getName(), preview.surfing().getTotalIndex()));
+        responses.put("Scuba", new ActivitySummaryResponse(preview.scuba().getName(), preview.scuba().getTotalIndex()));
 
-        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-        LocalDateTime endOfDay = startOfDay.plusDays(1);
-
-        List<OutdoorSpot> outdoorSpotList = outdoorSpotRepository.findByCoordinates(latitude, longitude, 10);
-
-        while (fishingBySpot == null || mudflatBySpot == null || surfingBySpot == null || scubaBySpot == null) {
-
-            OutdoorSpot currentSpot;
-            Long currentSpotId;
-
-            try {
-                currentSpot = outdoorSpotList.removeFirst();
-                currentSpotId = currentSpot.getId();
-            } catch (Exception e) {
-                break;
-            }
-
-            if (fishingBySpot == null) {
-                Optional<Fishing> fishingResult = fishingRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
-                    currentSpotId, startOfDay, endOfDay);
-
-                if (fishingResult.isPresent()) {
-                    fishingBySpot = fishingResult.get();
-                    responses.put("Fishing",
-                        new ActivitySummaryResponse(currentSpot.getName(), fishingResult.get().getTotalIndex()));
-                }
-            }
-
-            if (mudflatBySpot == null) {
-                Optional<Mudflat> mudflatResult = mudflatRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
-                    currentSpotId, startOfDay, endOfDay);
-
-                if (mudflatResult.isPresent()) {
-                    mudflatBySpot = mudflatResult.get();
-                    responses.put("Mudflat",
-                        new ActivitySummaryResponse(currentSpot.getName(), mudflatResult.get().getTotalIndex()));
-                }
-            }
-
-            if (surfingBySpot == null) {
-                Optional<Surfing> surfingResult = surfingRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
-                    currentSpotId, startOfDay, endOfDay);
-
-                if (surfingResult.isPresent()) {
-                    surfingBySpot = surfingResult.get();
-                    responses.put("Surfing",
-                        new ActivitySummaryResponse(currentSpot.getName(), surfingResult.get().getTotalIndex()));
-                }
-            }
-
-            if (scubaBySpot == null) {
-                Optional<Scuba> scubaResult = scubaRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
-                    currentSpotId, startOfDay, endOfDay);
-
-                if (scubaResult.isPresent()) {
-                    scubaBySpot = scubaResult.get();
-                    responses.put("Scuba",
-                        new ActivitySummaryResponse(currentSpot.getName(), scubaResult.get().getTotalIndex()));
-                }
-            }
-        }
+        // Fishing fishingBySpot = null;
+        // Mudflat mudflatBySpot = null;
+        // Surfing surfingBySpot = null;
+        // Scuba scubaBySpot = null;
+        //
+        // LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+        // LocalDateTime endOfDay = startOfDay.plusDays(1);
+        //
+        // List<OutdoorSpot> outdoorSpotList = outdoorSpotRepository.findByCoordinates(latitude, longitude, 10);
+        //
+        // while (fishingBySpot == null || mudflatBySpot == null || surfingBySpot == null || scubaBySpot == null) {
+        //
+        //     OutdoorSpot currentSpot;
+        //     Long currentSpotId;
+        //
+        //     try {
+        //         currentSpot = outdoorSpotList.removeFirst();
+        //         currentSpotId = currentSpot.getId();
+        //     } catch (Exception e) {
+        //         break;
+        //     }
+        //
+        //     if (fishingBySpot == null) {
+        //         Optional<Fishing> fishingResult = fishingRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
+        //             currentSpotId, startOfDay, endOfDay);
+        //
+        //         if (fishingResult.isPresent()) {
+        //             fishingBySpot = fishingResult.get();
+        //             responses.put("Fishing",
+        //                 new ActivitySummaryResponse(currentSpot.getName(), fishingResult.get().getTotalIndex()));
+        //         }
+        //     }
+        //
+        //     if (mudflatBySpot == null) {
+        //         Optional<Mudflat> mudflatResult = mudflatRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
+        //             currentSpotId, startOfDay, endOfDay);
+        //
+        //         if (mudflatResult.isPresent()) {
+        //             mudflatBySpot = mudflatResult.get();
+        //             responses.put("Mudflat",
+        //                 new ActivitySummaryResponse(currentSpot.getName(), mudflatResult.get().getTotalIndex()));
+        //         }
+        //     }
+        //
+        //     if (surfingBySpot == null) {
+        //         Optional<Surfing> surfingResult = surfingRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
+        //             currentSpotId, startOfDay, endOfDay);
+        //
+        //         if (surfingResult.isPresent()) {
+        //             surfingBySpot = surfingResult.get();
+        //             responses.put("Surfing",
+        //                 new ActivitySummaryResponse(currentSpot.getName(), surfingResult.get().getTotalIndex()));
+        //         }
+        //     }
+        //
+        //     if (scubaBySpot == null) {
+        //         Optional<Scuba> scubaResult = scubaRepository.findFirstBySpotIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(
+        //             currentSpotId, startOfDay, endOfDay);
+        //
+        //         if (scubaResult.isPresent()) {
+        //             scubaBySpot = scubaResult.get();
+        //             responses.put("Scuba",
+        //                 new ActivitySummaryResponse(currentSpot.getName(), scubaResult.get().getTotalIndex()));
+        //         }
+        //     }
+        // }
 
         return responses;
     }
@@ -128,17 +139,12 @@ public class ActivityService {
     private Map<String, ActivitySummaryResponse> getGlobalActivitySummary() {
         Map<String, ActivitySummaryResponse> responses = new HashMap<>();
 
-        LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
-        LocalDateTime endOfDay = startOfDay.plusDays(1);
+        LocalDate now = LocalDate.now();
 
-        Optional<Fishing> fishingResult = fishingRepository.findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(
-            startOfDay, endOfDay);
-        Optional<Mudflat> mudflatResult = mudflatRepository.findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(
-            startOfDay, endOfDay);
-        Optional<Surfing> surfingResult = surfingRepository.findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(
-            startOfDay, endOfDay);
-        Optional<Scuba> scubaResult = scubaRepository.findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(
-            startOfDay, endOfDay);
+        Optional<Fishing> fishingResult = fishingRepository.findBestTotaIndexFishing(now);
+        Optional<Mudflat> mudflatResult = mudflatRepository.findBestTotaIndexMudflat(now);
+        Optional<Surfing> surfingResult = surfingRepository.findBestTotaIndexSurfing(now);
+        Optional<Scuba> scubaResult = scubaRepository.findBestTotaIndexScuba(now);
 
         if (fishingResult.isPresent()) {
             Fishing fishing = fishingResult.get();
@@ -225,4 +231,6 @@ public class ActivityService {
             fishing.getSeaTempMax().toString()
         );
     }
+
+
 }

--- a/src/main/java/sevenstar/marineleisure/forecast/repository/FishingRepository.java
+++ b/src/main/java/sevenstar/marineleisure/forecast/repository/FishingRepository.java
@@ -118,6 +118,15 @@ public interface FishingRepository extends ActivityRepository<Fishing, Long> {
 		LocalDateTime endDateTime
 	);
 
+	@Query(value = """
+        SELECT *
+        FROM fishing_forecast f
+        WHERE f.forecast_date = :forecastDate
+        ORDER BY f.total_index DESC
+        LIMIT 1
+        """,nativeQuery = true)
+	Optional<Fishing> findBestTotaIndexFishing(@Param("forecastDate") LocalDate forecastDate);
+
 	Optional<Fishing> findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(LocalDateTime start,
 		LocalDateTime end);
 

--- a/src/main/java/sevenstar/marineleisure/forecast/repository/MudflatRepository.java
+++ b/src/main/java/sevenstar/marineleisure/forecast/repository/MudflatRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import jakarta.transaction.Transactional;
+import sevenstar.marineleisure.forecast.domain.Fishing;
 import sevenstar.marineleisure.forecast.domain.Mudflat;
 import sevenstar.marineleisure.spot.repository.ActivityRepository;
 
@@ -77,6 +78,15 @@ public interface MudflatRepository extends ActivityRepository<Mudflat, Long> {
 		LocalDateTime startDateTime,
 		LocalDateTime endDateTime
 	);
+
+	@Query(value = """
+		SELECT *
+		FROM mudflat_forecast m
+		WHERE m.forecast_date = :forecastDate
+		ORDER BY m.total_index DESC
+		LIMIT 1
+		""",nativeQuery = true)
+	Optional<Mudflat> findBestTotaIndexMudflat(@Param("forecastDate") LocalDate forecastDate);
 
 	Optional<Mudflat> findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/sevenstar/marineleisure/forecast/repository/ScubaRepository.java
+++ b/src/main/java/sevenstar/marineleisure/forecast/repository/ScubaRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 import jakarta.transaction.Transactional;
 import sevenstar.marineleisure.forecast.domain.Scuba;
+import sevenstar.marineleisure.forecast.domain.Surfing;
 import sevenstar.marineleisure.spot.repository.ActivityRepository;
 
 public interface ScubaRepository extends ActivityRepository<Scuba, Long> {
@@ -74,6 +75,15 @@ public interface ScubaRepository extends ActivityRepository<Scuba, Long> {
 		@Param("spotId") Long spotId,
 		@Param("forecastDate") LocalDate forecastDate
 	);
+
+	@Query(value = """
+        SELECT *
+        FROM scuba_forecast s
+        WHERE s.forecast_date = :forecastDate
+        ORDER BY s.total_index DESC
+        LIMIT 1
+        """,nativeQuery = true)
+	Optional<Scuba> findBestTotaIndexScuba(@Param("forecastDate") LocalDate forecastDate);
 
 	Optional<Scuba> findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/sevenstar/marineleisure/forecast/repository/SurfingRepository.java
+++ b/src/main/java/sevenstar/marineleisure/forecast/repository/SurfingRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import jakarta.transaction.Transactional;
+import sevenstar.marineleisure.forecast.domain.Fishing;
 import sevenstar.marineleisure.forecast.domain.Surfing;
 import sevenstar.marineleisure.spot.repository.ActivityRepository;
 
@@ -76,6 +77,15 @@ public interface SurfingRepository extends ActivityRepository<Surfing, Long> {
 		LocalDateTime startDateTime,
 		LocalDateTime endDateTime
 	);
+
+	@Query(value = """
+        SELECT *
+        FROM surfing_forecast s
+        WHERE s.forecast_date = :forecastDate
+        ORDER BY s.total_index DESC
+        LIMIT 1
+        """,nativeQuery = true)
+	Optional<Surfing> findBestTotaIndexSurfing(@Param("forecastDate") LocalDate forecastDate);
 
 	Optional<Surfing> findTopByCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByTotalIndexDesc(LocalDateTime start, LocalDateTime end);
 


### PR DESCRIPTION
* git initialize

* feature/swagger-03-gunwoong (#5)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feat: swagger 추가

* feat: swagger 추가

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/OpenAPI Test/02-HwuanPage

* feature/OpenAPI Test/02-HwuanPage

* Update SurfingForecastApiClient.java

* feature/APICallTest-02-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/JellyfishEntityInit-13-HwuanPage

* Update FishingType.java

* feature/EntityInitialize-13-HwuanPage

* feat: entity, repositor 구현

* feat: 예상 dto 구현

* chore: 의존성 추가

* feat: 로그인 구현 & 이후 토큰 발급 로직 구현

* fix: AuthCotnroller 수정

* fix: 클라이언트에서 카카오에서 코드를 받아 서버로 post 하게 수정

* feat: 토큰 검증

* feat: refresh token 블랙리스트 처리 로직 구현

* feat: refresh 토큰 블랙리스트 처리 & 재발급 로직 구현

* feat: SecurityFilterChain 엔드 포인트 허용

* feat: refresh 토큰 블랙리스트 검증 로직 구현

* feat: redis에서 refreshToken 블랙리스트 검증

* refactor: controller에 강하게 결합 되어 있던 로직들 분리

* test: member 관련 테스트

* chore: 하드코딩한 중요 값 Intellij IDEA 환경변수로 설정

* refactor: state 관리를 위해 세션 추가

* feat: member 정보 조회하는 서비스 로직 구현

* feat: member 정보 조회하는 서비스 로직 구현

* format: naver formatter로 포매팅

* chore: application-dev

* fix: customException 처리

* Feat/meeting interface (#19)

* feat : MeetingService 인터페이스 구현

* feat : ParticipantResponse

* feat : MeetingListResponse 구현

* feat : MeetingDetailResponse구현

* feat : MeetingDetailAndMemberResponse 구현

* feat : ListSpot 구현

* feat : DetailSpot 구현

* feat : CreateMeetingRequest 구현

* feat : Tag 구현

* feat : Long -> long 변경

서비스와 Entity내에서 null값이 절대 나오지 않는다고 판단하는 값을 long으로 변경하였습니다.

* feat : MeetingService.java

-> 무한페이지로딩형식으로 바꾸었습니다.

* Update src/main/java/sevenstar/marineleisure/meeting/Dto/Response/MeetingDetailResponse.java



---------



* Feature/FavoritesAndAlertInterface-16-HwuanPage

* feature/FavoritesAndAlertInterface-16-HwuanPage

* Update AlertMapper.java

* Update JellyfishRegionDensityRepository.java

* Update AlertController.java

* Update FavoriteController.java

* Update FavoriteRepository.java

* Update AlertController.java

* Update JellyfishSpieces.java

* Update JellyfishRegion.java

* Update JellyfishRegion.java

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* Feature/api scheduler 15 gunwoong (#28)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* test: remove legacy test

* feat: apply open meteo

* test: apply api test

* feat: spot service (#34)

* feat: spot service

* feat: spot service 고도화 및 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* hotfix: duplicated controller method

* feature/FavoriteCRUD-33-HwuanPage

* DELETE COMPLETE

* UPDATE COMPLETE

* search COMPLETE

* Before gunwoong

* FavoriteCRUD create

* feat/domain test

* FavoriteSpotServiceTest

* FavoriteSpotServiceTest

* feature/FavoriteCURD-33-HwuanPage

* add some description on service

* Update FavoriteServiceImpl.java

* Feature/spot preview 40 gunwoong (#41)

* feat: spot preview & 리팩토링

* feat: spot preview & 리팩토링

* hotfix: jpa metamodel fix

* fix: error fix

* fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생 (#42)

* fix: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 하던 버그 수정

* refactor: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 수정 사항 리팩토링

* test: 변경사항에 따른 테스트 코드 수정

* hofix: bug fix

* Feature/Alert-22-HwuanPage

* Create Pdf Parser

* Web crawler run perpectly,but pdfparser do not work well

* PDF parse to stack DB complete with OPENAI

* CallAlert Complete

* JellyFish PDF parsing work well

* feature/ControllerTest Complete

* feature/JellyfishAlert-26-HwuanPage

* feat: 즐겨찾기 추가 및 리팩토링 (#49)

* feat: 즐겨찾기 추가 및 리팩토링

* refactor: 리팩토링

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* Feature/integration init (#54)

* feature/IntegrationSet(test&Build)-52-HwuanPage

* data.sql unique update

* image build needs

* ignore dev.yml

* remove dev.yml tracking and ignore it

* prod

* proded

* Feature/activities 17 audwls239 (#56)

* feature: 컨트롤러, 서비스 생성

* feature: 활동별 지수 조회(위치 기반)

* feature: DTO 추가

* feature: 활동별 지수 조회(글로벌) 추가, 컨트롤러 수정

* feature: 활동별 지수 상세 조회(미완성)

* feature: 해양 정보 조회

* feature: 활동 상세 조회

---------



* feat : ParticipantError 입니다.

* hotfix: error fix

* fix : Directory 수정사항입니다. (#57)

* hotfix: error fix

* feat: member delete (#58)

* fix: 멤버 삭제 구현

* feat: 멤버 삭제, 위/경도 수정 구현

* test: 테스트 수정

* Delete src/main/java/sevenstar/marineleisure/meeting/repository/MemberRepository.java

* Delete src/main/java/sevenstar/marineleisure/meeting/repository/OutdoorSpotSpotRepository.java

* Delete src/main/resources/test.http

---------




* fix : ParticipantRepository (#59)

existsByMeetingIdAndUserId 로 수정하였습니다.

* fix : ParticipantRepository (#60)

memberId -> userId로 수정하였습니다.

* fix: token (#61)

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

# Conflicts:
#	src/main/java/sevenstar/marineleisure/global/exception/enums/CommonErrorCode.java #	src/main/java/sevenstar/marineleisure/global/swagger/SwaggerController.java

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* feat: 테스트용 액세스 토큰 생성

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* Feature/api scheduler 15 gunwoong (#28)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* test: remove legacy test

* feat: apply open meteo

* test: apply api test

* feature/FavoriteCRUD-33-HwuanPage

* DELETE COMPLETE

* UPDATE COMPLETE

* search COMPLETE

* Before gunwoong

* FavoriteCRUD create

* feat/domain test

* FavoriteSpotServiceTest

* FavoriteSpotServiceTest

* feature/FavoriteCURD-33-HwuanPage

* add some description on service

* Update FavoriteServiceImpl.java

* fix: error fix

* fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생 (#42)

* fix: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 하던 버그 수정

* refactor: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 수정 사항 리팩토링

* test: 변경사항에 따른 테스트 코드 수정

* hofix: bug fix

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

# Conflicts:
#	src/main/java/sevenstar/marineleisure/global/exception/enums/CommonErrorCode.java #	src/main/java/sevenstar/marineleisure/global/swagger/SwaggerController.java

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* fix : jellyfish 부분

* fix: activity 부분

* fix: member 부분

* fix: member 부분

* fix: spot 부분

* fix: forecast 부분

* fix: favorite 부분

* fix: alert 부분

* fix: meeting 부분

---------







* hotfix/fix-alert&favorites-62-HwuanPage

* fix(hotfix/Meeting) : rebase로 인한 코드 누락 수정 (#65)

* hotfix: 코드 누락 해결 (#67)

* Fix/fix 70 gunwoong (#71)

* hotfix: fix

* hotfix: fix

* hotfix: fix

* fix: application-prod.yml에서 쿠키를 쓸지 말지 결정할 수 있게 수정 (#69)

* fix: application-prod.yml에서 쿠키를 쓸지 말지 결정할 수 있게 수정

* test: 테스트 코드 작성

* fix: activities 시큐리티 엔드포인트 허용. redirecturi 수정

* Chore/docker set andvariable-68-hwuanPage

* chore/ReadytoDeployv1.0.0-68-HuwanPage

* chore/ReadytoDeploymentv1.0.0-68-HuwanPage

* remove etc

* prod

* refactor: blacklist 엔티티의 jti에 인덱스를 건다. (#74)

* Feat/meeting test 75 (#77)

* feat : Meetingtest 를 위한 Util 파일입니니다.

* feat : Meetingtest 를 위한 Util 파일입니니다.

* feat : MeetingServiceImplTest 단위테스트입니다.

* feat : MeetingControllerTest 통합테스트입니다.

* feat : Build Lombok을 테스트를 위한 수정입니다.

* feat : Tag 엔티티

Tag List<String> content 를 변환하기 위한 파일입니다.

* feat : MeetingServiceImpl

* feat : MeetingServiceImpl에서 수정하는 응답을 수정 , 매퍼를 수정하였습니다.

* feat : Meeting에서 필요한 url을 열어뒀습니다.

* space prob solve

* stack-trace-DEBUG

* hotfix/data.sql deprecate-HwuanPage (#79)

* hotfix/data.sql deprecate-HwuanPage

* portnum fix

* Xtest

* test X

* workflow fix

* add id

* fix docker-compose-image-root

* release/v1-marineleisure

* fix: blacklist 엔티티의 jti에 인덱스를 건다. (#83)

* fix: cors 프론트엔드 배포 도메인 추가 (#84)

* fix: blacklist 엔티티의 jti에 인덱스를 건다.

* fix: cors 프로트엔드 도메인 추가

* hotfix/method_allowed_patch-HwuanPage (#86)

* Refactor/exception hwuan page (#87)

* refacotr/favorite-Exception-update

* fix kakao_redirect_uri

* Feature/map service refactoring 76 gunwoong (#85)

* feat: mapServiceRefactoring

* refactoring: spot detail refactoring

* refactoring: GeoUtils refactoring

* test: repository test disable for prod

* fix: apply flyway to yml

* fix: disable test

* refactor: khoa refactoring

* fix: bug

* fix: sql

* fix: yml 환경변수 추가

* fix: detail field name 수정

* feature: 스케줄링 비동기 구현 (#91)

* refactor: cacheable (#103)

* Fix/meeting urland role (#100)

* fix : MeetingServiceImpl
getStatusMeetings -> getStatusMeeting_role : Guest 인지 host 인지 판단하는 로직을 추가

* fix : MeetingRepository

getStatusMeetings -> getStatusMeeting_role : Guest 인지 host 인지 판단하는 로직을 추가

* fix : MeetingError

MEETING_MEMBER_NOT_FOUND 에러를 추가하였습니다. 미팅에서 맴버를 확인할 수 없는 에러입니다.

* fix : MeetingController

MeetingController 에서 role 을 확인하여 추가 확인할 수 있도록 하였습니다.

* fix : MeetingServiceImplTest, MeetingControllerTest.java

URL 개선에 의한 새로운 테스트 입니다.

* fix : MeetingServiceImplTest, MeetingControllerTest.java

@Disabled 추가 하였습니다.

* feat: 회원 탈퇴 시 카카오 연결 끊기도 수행하게 구현한다. (#98)

* feat: member 삭제 시 kakao 연결 끊기 로직도 수행하게 구현

* test: 변경 사항 test

* feat : Meeting의 커서방식에서 매핑을 하였습니다. (#94)

* feat: 카카오 로그인 과정에서 pkce를 통해 보안 관점에서 개선 (#106)

* feat: 보안 인증 과정에서 PKCE 추가하여 구현

* test: 변경 사항 test 추가

* feat: PKCE 기반 보안 기능 코드 구조 변경

* test: PKCE 기반 보안 기능 test

* refactor: PKCE 생성을 클라이언트 에게 넘긴다.

* test: pkce test 플로우 변경에 따라 변경

* fix: member entity의 nickname 중복을 허용한다

* fix: 테스트를 위해 SchedulerService.java 의 @RequiredArgsConstrucor 지운 부분 복구

* fix: 테스트를 위해 SchedulerService.java 의 @RequiredArgsConstrucor 지운 부분 복구

* refactor: open-meteo 서비스 관련 리팩토링 (#95)

* refactor: RichDomain으로 변경 내역입니다. (#105)

* Fix: login redirect (#107)

* fix: 로그인 요청때의 리다이렉트 uri를 토큰 교환시에도 사용

* test: test

* fix: fallback 상황에서 리다이렉트 uri 찾는 로직 추가

* Refactor/meeting rich domain (#110)

* refactor: RichDomain으로 변경 내역입니다.

* refactor: 누락 프로젝트 파일이 있어 첨부합니다.

* build: caffenine 적용

* relase (#111) (#112)

* git initialize

* feature/swagger-03-gunwoong (#5)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feat: swagger 추가

* feat: swagger 추가

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/OpenAPI Test/02-HwuanPage

* feature/OpenAPI Test/02-HwuanPage

* Update SurfingForecastApiClient.java

* feature/APICallTest-02-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/JellyfishEntityInit-13-HwuanPage

* Update FishingType.java

* feature/EntityInitialize-13-HwuanPage

* feat: entity, repositor 구현

* feat: 예상 dto 구현

* chore: 의존성 추가

* feat: 로그인 구현 & 이후 토큰 발급 로직 구현

* fix: AuthCotnroller 수정

* fix: 클라이언트에서 카카오에서 코드를 받아 서버로 post 하게 수정

* feat: 토큰 검증

* feat: refresh token 블랙리스트 처리 로직 구현

* feat: refresh 토큰 블랙리스트 처리 & 재발급 로직 구현

* feat: SecurityFilterChain 엔드 포인트 허용

* feat: refresh 토큰 블랙리스트 검증 로직 구현

* feat: redis에서 refreshToken 블랙리스트 검증

* refactor: controller에 강하게 결합 되어 있던 로직들 분리

* test: member 관련 테스트

* chore: 하드코딩한 중요 값 Intellij IDEA 환경변수로 설정

* refactor: state 관리를 위해 세션 추가

* feat: member 정보 조회하는 서비스 로직 구현

* feat: member 정보 조회하는 서비스 로직 구현

* format: naver formatter로 포매팅

* chore: application-dev

* fix: customException 처리

* Feat/meeting interface (#19)

* feat : MeetingService 인터페이스 구현

* feat : ParticipantResponse

* feat : MeetingListResponse 구현

* feat : MeetingDetailResponse구현

* feat : MeetingDetailAndMemberResponse 구현

* feat : ListSpot 구현

* feat : DetailSpot 구현

* feat : CreateMeetingRequest 구현

* feat : Tag 구현

* feat : Long -> long 변경

서비스와 Entity내에서 null값이 절대 나오지 않는다고 판단하는 값을 long으로 변경하였습니다.

* feat : MeetingService.java

-> 무한페이지로딩형식으로 바꾸었습니다.

* Update src/main/java/sevenstar/marineleisure/meeting/Dto/Response/MeetingDetailResponse.java



---------



* Feature/FavoritesAndAlertInterface-16-HwuanPage

* feature/FavoritesAndAlertInterface-16-HwuanPage

* Update AlertMapper.java

* Update JellyfishRegionDensityRepository.java

* Update AlertController.java

* Update FavoriteController.java

* Update FavoriteRepository.java

* Update AlertController.java

* Update JellyfishSpieces.java

* Update JellyfishRegion.java

* Update JellyfishRegion.java

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* Feature/api scheduler 15 gunwoong (#28)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* test: remove legacy test

* feat: apply open meteo

* test: apply api test

* feat: spot service (#34)

* feat: spot service

* feat: spot service 고도화 및 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* hotfix: duplicated controller method

* feature/FavoriteCRUD-33-HwuanPage

* DELETE COMPLETE

* UPDATE COMPLETE

* search COMPLETE

* Before gunwoong

* FavoriteCRUD create

* feat/domain test

* FavoriteSpotServiceTest

* FavoriteSpotServiceTest

* feature/FavoriteCURD-33-HwuanPage

* add some description on service

* Update FavoriteServiceImpl.java

* Feature/spot preview 40 gunwoong (#41)

* feat: spot preview & 리팩토링

* feat: spot preview & 리팩토링

* hotfix: jpa metamodel fix

* fix: error fix

* fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생 (#42)

* fix: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 하던 버그 수정

* refactor: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 수정 사항 리팩토링

* test: 변경사항에 따른 테스트 코드 수정

* hofix: bug fix

* Feature/Alert-22-HwuanPage

* Create Pdf Parser

* Web crawler run perpectly,but pdfparser do not work well

* PDF parse to stack DB complete with OPENAI

* CallAlert Complete

* JellyFish PDF parsing work well

* feature/ControllerTest Complete

* feature/JellyfishAlert-26-HwuanPage

* feat: 즐겨찾기 추가 및 리팩토링 (#49)

* feat: 즐겨찾기 추가 및 리팩토링

* refactor: 리팩토링

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* Feature/integration init (#54)

* feature/IntegrationSet(test&Build)-52-HwuanPage

* data.sql unique update

* image build needs

* ignore dev.yml

* remove dev.yml tracking and ignore it

* prod

* proded

* Feature/activities 17 audwls239 (#56)

* feature: 컨트롤러, 서비스 생성

* feature: 활동별 지수 조회(위치 기반)

* feature: DTO 추가

* feature: 활동별 지수 조회(글로벌) 추가, 컨트롤러 수정

* feature: 활동별 지수 상세 조회(미완성)

* feature: 해양 정보 조회

* feature: 활동 상세 조회

---------



* feat : ParticipantError 입니다.

* hotfix: error fix

* fix : Directory 수정사항입니다. (#57)

* hotfix: error fix

* feat: member delete (#58)

* fix: 멤버 삭제 구현

* feat: 멤버 삭제, 위/경도 수정 구현

* test: 테스트 수정

* Delete src/main/java/sevenstar/marineleisure/meeting/repository/MemberRepository.java

* Delete src/main/java/sevenstar/marineleisure/meeting/repository/OutdoorSpotSpotRepository.java

* Delete src/main/resources/test.http

---------




* fix : ParticipantRepository (#59)

existsByMeetingIdAndUserId 로 수정하였습니다.

* fix : ParticipantRepository (#60)

memberId -> userId로 수정하였습니다.

* fix: token (#61)

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

# Conflicts:
#	src/main/java/sevenstar/marineleisure/global/exception/enums/CommonErrorCode.java #	src/main/java/sevenstar/marineleisure/global/swagger/SwaggerController.java

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* feat: 테스트용 액세스 토큰 생성

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* Feature/api scheduler 15 gunwoong (#28)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* test: remove legacy test

* feat: apply open meteo

* test: apply api test

* feature/FavoriteCRUD-33-HwuanPage

* DELETE COMPLETE

* UPDATE COMPLETE

* search COMPLETE

* Before gunwoong

* FavoriteCRUD create

* feat/domain test

* FavoriteSpotServiceTest

* FavoriteSpotServiceTest

* feature/FavoriteCURD-33-HwuanPage

* add some description on service

* Update FavoriteServiceImpl.java

* fix: error fix

* fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생 (#42)

* fix: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 하던 버그 수정

* refactor: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 수정 사항 리팩토링

* test: 변경사항에 따른 테스트 코드 수정

* hofix: bug fix

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

# Conflicts:
#	src/main/java/sevenstar/marineleisure/global/exception/enums/CommonErrorCode.java #	src/main/java/sevenstar/marineleisure/global/swagger/SwaggerController.java

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 코드 적용이 필요합니다.
   * `createMeeting(Long memberId, CreateMeetingRequest request)`: * 목적: 새로운 모임을 생성합니다. 호스트를 참여자로 자동 등록하고 태그 정보를 저장합니다.
   * `updateMeeting(Long meetingId, Long memberId, UpdateMeetingRequest request)`:
       * 목적: 기존 모임의 정보를 수정합니다. 호스트만 수정할 수 있도록 검증합니다.
   * `deleteMeeting(Member member, Long meetingId)`: * 목적: 모임을 삭제합니다. * 개선 예정: 물리적 삭제 대신 논리적 삭제(Soft Delete) 방식 도입을 고려 중입니다.

* feat : MeetingValidate.java,MemberValidate.java,ParticipantValidate,SpotValidate,TagValidate.java

검증로직을 추가하였습니다.

* feat : MemberError.java , ParticipantRepository

기능을 추가하였습니다.

---------



* fix : jellyfish 부분

* fix: activity 부분

* fix: member 부분

* fix: member 부분

* fix: spot 부분

* fix: forecast 부분

* fix: favorite 부분

* fix: alert 부분

* fix: meeting 부분

---------







* hotfix/fix-alert&favorites-62-HwuanPage

* fix(hotfix/Meeting) : rebase로 인한 코드 누락 수정 (#65)

* hotfix: 코드 누락 해결 (#67)

* Fix/fix 70 gunwoong (#71)

* hotfix: fix

* hotfix: fix

* hotfix: fix

* fix: application-prod.yml에서 쿠키를 쓸지 말지 결정할 수 있게 수정 (#69)

* fix: application-prod.yml에서 쿠키를 쓸지 말지 결정할 수 있게 수정

* test: 테스트 코드 작성

* fix: activities 시큐리티 엔드포인트 허용. redirecturi 수정

* Chore/docker set andvariable-68-hwuanPage

* chore/ReadytoDeployv1.0.0-68-HuwanPage

* chore/ReadytoDeploymentv1.0.0-68-HuwanPage

* remove etc

* prod

* refactor: blacklist 엔티티의 jti에 인덱스를 건다. (#74)

* Feat/meeting test 75 (#77)

* feat : Meetingtest 를 위한 Util 파일입니니다.

* feat : Meetingtest 를 위한 Util 파일입니니다.

* feat : MeetingServiceImplTest 단위테스트입니다.

* feat : MeetingControllerTest 통합테스트입니다.

* feat : Build Lombok을 테스트를 위한 수정입니다.

* feat : Tag 엔티티

Tag List<String> content 를 변환하기 위한 파일입니다.

* feat : MeetingServiceImpl

* feat : MeetingServiceImpl에서 수정하는 응답을 수정 , 매퍼를 수정하였습니다.

* feat : Meeting에서 필요한 url을 열어뒀습니다.

* space prob solve

* stack-trace-DEBUG

* hotfix/data.sql deprecate-HwuanPage (#79)

* hotfix/data.sql deprecate-HwuanPage

* portnum fix

* Xtest

* test X

* workflow fix

* add id

* fix docker-compose-image-root

* release/v1-marineleisure

* fix: blacklist 엔티티의 jti에 인덱스를 건다. (#83)

* fix: cors 프론트엔드 배포 도메인 추가 (#84)

* fix: blacklist 엔티티의 jti에 인덱스를 건다.

* fix: cors 프로트엔드 도메인 추가

* hotfix/method_allowed_patch-HwuanPage (#86)

* Refactor/exception hwuan page (#87)

* refacotr/favorite-Exception-update

* fix kakao_redirect_uri

* Feature/map service refactoring 76 gunwoong (#85)

* feat: mapServiceRefactoring

* refactoring: spot detail refactoring

* refactoring: GeoUtils refactoring

* test: repository test disable for prod

* fix: apply flyway to yml

* fix: disable test

* refactor: khoa refactoring

* fix: bug

* fix: sql

* fix: yml 환경변수 추가

* fix: detail field name 수정

* feature: 스케줄링 비동기 구현 (#91)

* refactor: cacheable (#103)

* Fix/meeting urland role (#100)

* fix : MeetingServiceImpl
getStatusMeetings -> getStatusMeeting_role : Guest 인지 host 인지 판단하는 로직을 추가

* fix : MeetingRepository

getStatusMeetings -> getStatusMeeting_role : Guest 인지 host 인지 판단하는 로직을 추가

* fix : MeetingError

MEETING_MEMBER_NOT_FOUND 에러를 추가하였습니다. 미팅에서 맴버를 확인할 수 없는 에러입니다.

* fix : MeetingController

MeetingController 에서 role 을 확인하여 추가 확인할 수 있도록 하였습니다.

* fix : MeetingServiceImplTest, MeetingControllerTest.java

URL 개선에 의한 새로운 테스트 입니다.

* fix : MeetingServiceImplTest, MeetingControllerTest.java

@Disabled 추가 하였습니다.

* feat: 회원 탈퇴 시 카카오 연결 끊기도 수행하게 구현한다. (#98)

* feat: member 삭제 시 kakao 연결 끊기 로직도 수행하게 구현

* test: 변경 사항 test

* feat : Meeting의 커서방식에서 매핑을 하였습니다. (#94)

* feat: 카카오 로그인 과정에서 pkce를 통해 보안 관점에서 개선 (#106)

* feat: 보안 인증 과정에서 PKCE 추가하여 구현

* test: 변경 사항 test 추가

* feat: PKCE 기반 보안 기능 코드 구조 변경

* test: PKCE 기반 보안 기능 test

* refactor: PKCE 생성을 클라이언트 에게 넘긴다.

* test: pkce test 플로우 변경에 따라 변경

* fix: member entity의 nickname 중복을 허용한다

* fix: 테스트를 위해 SchedulerService.java 의 @RequiredArgsConstrucor 지운 부분 복구

* fix: 테스트를 위해 SchedulerService.java 의 @RequiredArgsConstrucor 지운 부분 복구

* refactor: open-meteo 서비스 관련 리팩토링 (#95)

* refactor: RichDomain으로 변경 내역입니다. (#105)

* Fix: login redirect (#107)

* fix: 로그인 요청때의 리다이렉트 uri를 토큰 교환시에도 사용

* test: test

* fix: fallback 상황에서 리다이렉트 uri 찾는 로직 추가

* Refactor/meeting rich domain (#110)

* refactor: RichDomain으로 변경 내역입니다.

* refactor: 누락 프로젝트 파일이 있어 첨부합니다.

* build: caffenine 적용

---------








* fix: fallback 상황에서 리다이렉트 uri 찾는 로직 추가 (#113)

* release (#114) (#115)

* git initialize

* feature/swagger-03-gunwoong (#5)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feat: swagger 추가

* feat: swagger 추가

* feature/base domain 04 gunwoong (#6)

* feat: 공통 도메인 구현

* feat: 메인 어플리케이션에 추가

* feature/OpenAPI Test/02-HwuanPage

* feature/OpenAPI Test/02-HwuanPage

* Update SurfingForecastApiClient.java

* feature/APICallTest-02-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/EntityInit-13-HwuanPage

* feature/JellyfishEntityInit-13-HwuanPage

* Update FishingType.java

* feature/EntityInitialize-13-HwuanPage

* feat: entity, repositor 구현

* feat: 예상 dto 구현

* chore: 의존성 추가

* feat: 로그인 구현 & 이후 토큰 발급 로직 구현

* fix: AuthCotnroller 수정

* fix: 클라이언트에서 카카오에서 코드를 받아 서버로 post 하게 수정

* feat: 토큰 검증

* feat: refresh token 블랙리스트 처리 로직 구현

* feat: refresh 토큰 블랙리스트 처리 & 재발급 로직 구현

* feat: SecurityFilterChain 엔드 포인트 허용

* feat: refresh 토큰 블랙리스트 검증 로직 구현

* feat: redis에서 refreshToken 블랙리스트 검증

* refactor: controller에 강하게 결합 되어 있던 로직들 분리

* test: member 관련 테스트

* chore: 하드코딩한 중요 값 Intellij IDEA 환경변수로 설정

* refactor: state 관리를 위해 세션 추가

* feat: member 정보 조회하는 서비스 로직 구현

* feat: member 정보 조회하는 서비스 로직 구현

* format: naver formatter로 포매팅

* chore: application-dev

* fix: customException 처리

* Feat/meeting interface (#19)

* feat : MeetingService 인터페이스 구현

* feat : ParticipantResponse

* feat : MeetingListResponse 구현

* feat : MeetingDetailResponse구현

* feat : MeetingDetailAndMemberResponse 구현

* feat : ListSpot 구현

* feat : DetailSpot 구현

* feat : CreateMeetingRequest 구현

* feat : Tag 구현

* feat : Long -> long 변경

서비스와 Entity내에서 null값이 절대 나오지 않는다고 판단하는 값을 long으로 변경하였습니다.

* feat : MeetingService.java

-> 무한페이지로딩형식으로 바꾸었습니다.

* Update src/main/java/sevenstar/marineleisure/meeting/Dto/Response/MeetingDetailResponse.java



---------



* Feature/FavoritesAndAlertInterface-16-HwuanPage

* feature/FavoritesAndAlertInterface-16-HwuanPage

* Update AlertMapper.java

* Update JellyfishRegionDensityRepository.java

* Update AlertController.java

* Update FavoriteController.java

* Update FavoriteRepository.java

* Update AlertController.java

* Update JellyfishSpieces.java

* Update JellyfishRegion.java

* Update JellyfishRegion.java

* feature/CustomExceptionInit-22-HwuanPage

* feature/CustomExceptionInit-22-HwuanPage

* Errorcode interface Change

* Refactor application.yml 환경변수 설정 (#25)

* refactor: application.yml 환경변수 설정
* Rename: 오타 수정

* Feature/spot service interface 29 gunwoong (#30)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* Feature/api scheduler 15 gunwoong (#28)

* feat: api

* feat: api 스케줄링

* feat: spot service inteface

* test: remove legacy test

* feat: apply open meteo

* test: apply api test

* feat: spot service (#34)

* feat: spot service

* feat: spot service 고도화 및 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* feat: 조회도 관련 서비스 추가

* hotfix: duplicated controller method

* feature/FavoriteCRUD-33-HwuanPage

* DELETE COMPLETE

* UPDATE COMPLETE

* search COMPLETE

* Before gunwoong

* FavoriteCRUD create

* feat/domain test

* FavoriteSpotServiceTest

* FavoriteSpotServiceTest

* feature/FavoriteCURD-33-HwuanPage

* add some description on service

* Update FavoriteServiceImpl.java

* Feature/spot preview 40 gunwoong (#41)

* feat: spot preview & 리팩토링

* feat: spot preview & 리팩토링

* hotfix: jpa metamodel fix

* fix: error fix

* fix: 소셜 로그인 재시도 시 닉네임 UNIQUE 제약 위반 오류 발생 (#42)

* fix: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 하던 버그 수정

* refactor: 로그아웃 후 재로그인 시 동일 정보로 db에 insert 수정 사항 리팩토링

* test: 변경사항에 따른 테스트 코드 수정

* hofix: bug fix

* Feature/Alert-22-HwuanPage

* Create Pdf Parser

* Web crawler run perpectly,but pdfparser do not work well

* PDF parse to stack DB complete with OPENAI

* CallAlert Complete

* JellyFish PDF parsing work well

* feature/ControllerTest Complete

* feature/JellyfishAlert-26-HwuanPage

* feat: 즐겨찾기 추가 및 리팩토링 (#49)

* feat: 즐겨찾기 추가 및 리팩토링

* refactor: 리팩토링

* feat: 카카오 로그인을 stateless 하게 변경한다 (#51)

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경

* refactor: 기존 state 사용 방식 -> stateless 방식으로 변경으로 인해 필요 없는 엔드 포인트 삭제

* test: 변경사항 test 수정

* feat: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 코드 구현

* test: 카카오 측에서 인증 실패시에 반환 하는 에러 처리하는 테스트 추가

* fix: 주석 제거

* fix: exception 변경

* Feat/meeting service (#46)

* WIP: Rebase를 위한 임시 저장

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* feat : Meeting.java

-> Meeting 엔터티 @Builder 를 상위 어노테이션에 일단 추가시켰습니다.

* Delete MeetingServiceImplReview.md

* Delete MeetingServiceUserFlow.md

* feat : 패키지명 변경 이슈

-> 패키지 명을 컨벤션에 따른 이름으로 변경했습니다.

* feat : MeetingController.java

long participantCount = participantRepository.countMeetingIdMember ->
long participantCount = participantRepository.countMeetingId로 수정하였습니다.

* feat : MeetingError.java

MeetingError.java 를 추가하였습니다.

* feat : MeetingMapper

MeetingServiceImpl에서 사용중이었던 Mapper를 분리하였습니다.

* feat : MeetingService.java

패키지 명 수정으로 인해서 수정사항이 있었습니다.

* feat : MeetingServiceImpl.java

트랜잭션 관리 명확화 하였습니다.
validate 패키지를 개선하였습니다.
joinMeeting 중복 참여 제한 로직을 강화하였습니다.

  * `getAllMeetings(Long cursorId, int size)`: * 목적: 모든 모임 목록을 페이징 처리하여 조회합니다. cursorId를 사용하여 무한 스크롤과 같은 커서 기반 페이징을 지원합니다. * 특징: @Transactional(readOnly = true)를 통해 읽기 전용 트랜잭션으로 최적화되었습니다.
   * `getMeetingDetails(Long meetingId)`: * 목적: 특정 모임의 상세 정보를 조회합니다. 호스트, 장소, 태그 등 연관된 정보를 함께 가져옵니다. * 개선 예정: 현재 N+1 문제가 발생할 수 있어, 향후 Fetch Join을 통한 성능 최적화가 필요합니다.
   * `getStatusMyMeetings(Long memberId, Long cursorId, int size, MeetingStatus meetingStatus)`:
       * 목적: 특정 회원의 상태별(예: 모집 중, 완료) 모임 목록을 페이징 처리하여 조회합니다.
   * `getMeetingDetailAndMember(Long memberId, Long meetingId)`: * 목적: 호스트가 자신의 모임 상세 정보와 참여자 목록을 조회합니다. 참여자들의 닉네임을 함께 제공합니다.
   * `countMeetings(Long memberId)`:
       * 목적: 특정 회원이 참여한 모임의 총 개수를 반환합니다.
   * `joinMeeting(Long meetingId, Long memberId)`: * 목적: 회원이 특정 모임에 참여합니다. * 주요 개선: 모임 상태 검증(verifyRecruiting), 중복 참여 검증(`verifyNotAlreadyParticipant`), 모임 정원 초과 검증(verifyMeetingCount) 로직이 강화되었습니다. * 개선 예정: 동시성 문제(Race Condition) 해결을 위한 비관적 락(Pessimistic Lock) 적용이 필요합니다.
   * `leaveMeeting(Long meetingId, Long memberId)`:
       * 목적: 회원이 모임에서 탈퇴합니다.
       * 주요 개선: 호스트 탈퇴 방지(verifyNotHost), 모임 상태에 따른 탈퇴 가능 여부 검증(verifyLeave) 로직이 추가되었습니다. * 개선 예정: MEETING_NOT_FOUND 대신 CANNOT_LEAVE_COMPLETED_MEETING과 같은 더 구체적인 에러 …

- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용

## 스크린샷

## 주의사항

Closes #{이슈 번호}
