### PR TITLE
[feature]MeetingScheduler

### DIFF
--- a/src/main/java/sevenstar/marineleisure/meeting/controller/MeetingSchedulerController.java
+++ b/src/main/java/sevenstar/marineleisure/meeting/controller/MeetingSchedulerController.java
@@ -1,0 +1,35 @@
+package sevenstar.marineleisure.meeting.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import sevenstar.marineleisure.global.domain.BaseResponse;
+import sevenstar.marineleisure.meeting.service.util.MeetingStatusScheduler;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class MeetingSchedulerController {
+    
+    private final MeetingStatusScheduler meetingStatusScheduler;
+    
+    @PostMapping("/meetings/complete-expired")
+    public ResponseEntity<BaseResponse<String>> completeExpiredMeetings() {
+        try {
+            log.info("관리자에 의한 수동 미팅 상태 업데이트 요청");
+            meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+            
+            return BaseResponse.success(HttpStatus.OK, "만료된 미팅들의 상태가 성공적으로 COMPLETED로 변경되었습니다.");
+        } catch (Exception e) {
+            log.error("미팅 상태 업데이트 중 오류 발생: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new BaseResponse<>(500, "미팅 상태 업데이트 중 오류가 발생했습니다.", null));
+        }
+    }
+}

--- a/src/main/java/sevenstar/marineleisure/meeting/service/util/MeetingStatusScheduler.java
+++ b/src/main/java/sevenstar/marineleisure/meeting/service/util/MeetingStatusScheduler.java
@@ -1,0 +1,45 @@
+package sevenstar.marineleisure.meeting.service.util;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import sevenstar.marineleisure.global.enums.MeetingStatus;
+import sevenstar.marineleisure.meeting.domain.Meeting;
+import sevenstar.marineleisure.meeting.repository.MeetingRepository;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MeetingStatusScheduler {
+    
+    private final MeetingRepository meetingRepository;
+    
+    @Scheduled(cron = "0 */10 * * * *") // 10분마다 실행
+    @Transactional
+    public void updateExpiredMeetingsToCompleted() {
+        LocalDateTime now = LocalDateTime.now();
+        
+        // 미팅 시간이 지났지만 COMPLETED가 아닌 모든 미팅 조회
+        List<Meeting> expiredMeetings = meetingRepository.findExpiredMeetingsNotCompleted(now, MeetingStatus.COMPLETED);
+        
+        if (!expiredMeetings.isEmpty()) {
+            log.info("미팅 시간이 지난 {} 개의 미팅을 COMPLETED 상태로 변경합니다.", expiredMeetings.size());
+            
+            for (Meeting meeting : expiredMeetings) {
+                log.debug("미팅 ID: {}, 제목: {}, 미팅시간: {}, 현재상태: {} -> COMPLETED로 변경", 
+                    meeting.getId(), meeting.getTitle(), meeting.getMeetingTime(), meeting.getStatus());
+                
+                meeting.changeStatus(MeetingStatus.COMPLETED);
+            }
+            
+            meetingRepository.saveAll(expiredMeetings);
+            log.info("총 {} 개 미팅의 상태를 COMPLETED로 변경 완료", expiredMeetings.size());
+        }
+    }
+}

--- a/src/test/java/sevenstar/marineleisure/meeting/controller/MeetingSchedulerControllerTest.java
+++ b/src/test/java/sevenstar/marineleisure/meeting/controller/MeetingSchedulerControllerTest.java
@@ -1,0 +1,223 @@
+package sevenstar.marineleisure.meeting.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import sevenstar.marineleisure.meeting.service.util.MeetingStatusScheduler;
+
+@WebMvcTest(controllers = MeetingSchedulerController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+@Slf4j
+class MeetingSchedulerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MeetingStatusScheduler meetingStatusScheduler;
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 만료된 미팅 상태 업데이트 성공")
+    void completeExpiredMeetings_Success() throws Exception {
+        // given
+        doNothing().when(meetingStatusScheduler).updateExpiredMeetingsToCompleted();
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+        String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+            .writeValueAsString(jsonObject);
+
+        log.info("Complete Expired Meetings Success Response:");
+        log.info("prettyJson == {}", prettyJson);
+
+        verify(meetingStatusScheduler, times(1)).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 스케줄러 실행 중 예외 발생")
+    void completeExpiredMeetings_Exception() throws Exception {
+        // given
+        doThrow(new RuntimeException("Database connection error"))
+            .when(meetingStatusScheduler).updateExpiredMeetingsToCompleted();
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isInternalServerError())
+            .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+        String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+            .writeValueAsString(jsonObject);
+
+        log.info("Complete Expired Meetings Exception Response:");
+        log.info("prettyJson == {}", prettyJson);
+
+        verify(meetingStatusScheduler, times(1)).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 여러 번 연속 호출")
+    void completeExpiredMeetings_MultipleCalls() throws Exception {
+        // given
+        doNothing().when(meetingStatusScheduler).updateExpiredMeetingsToCompleted();
+
+        // when & then - 첫 번째 호출
+        mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk());
+
+        // when & then - 두 번째 호출
+        mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk());
+
+        // when & then - 세 번째 호출
+        MvcResult mvcResult = mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+        String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+            .writeValueAsString(jsonObject);
+
+        log.info("Multiple Calls Response:");
+        log.info("prettyJson == {}", prettyJson);
+
+        // 총 3번 호출되었는지 확인
+        verify(meetingStatusScheduler, times(3)).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 잘못된 HTTP 메서드 사용")
+    void completeExpiredMeetings_WrongHttpMethod() throws Exception {
+        // when & then - GET 메서드로 호출 시 405 Method Not Allowed
+        mockMvc.perform(
+            get("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isMethodNotAllowed());
+
+        // when & then - PUT 메서드로 호출 시 405 Method Not Allowed
+        mockMvc.perform(
+            put("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isMethodNotAllowed());
+
+        // when & then - DELETE 메서드로 호출 시 405 Method Not Allowed
+        mockMvc.perform(
+            delete("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isMethodNotAllowed());
+
+        // 스케줄러가 호출되지 않았는지 확인
+        verify(meetingStatusScheduler, never()).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 잘못된 URL 경로")
+    void completeExpiredMeetings_WrongPath() throws Exception {
+        // when & then - 잘못된 경로로 호출 시 404 Not Found
+        mockMvc.perform(
+            post("/api/admin/meetings/complete-expired-wrong")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isNotFound());
+
+        mockMvc.perform(
+            post("/api/admin/meeting/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isNotFound());
+
+        // 스케줄러가 호출되지 않았는지 확인
+        verify(meetingStatusScheduler, never()).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - Content-Type 헤더 테스트")
+    void completeExpiredMeetings_ContentType() throws Exception {
+        // given
+        doNothing().when(meetingStatusScheduler).updateExpiredMeetingsToCompleted();
+
+        // when & then - JSON Content-Type으로 호출
+        MvcResult mvcResult = mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        Object jsonObject = objectMapper.readValue(responseBody, Object.class);
+        String prettyJson = objectMapper.writerWithDefaultPrettyPrinter()
+            .writeValueAsString(jsonObject);
+
+        log.info("Content-Type Test Response:");
+        log.info("prettyJson == {}", prettyJson);
+
+        verify(meetingStatusScheduler, times(1)).updateExpiredMeetingsToCompleted();
+    }
+
+    @Test
+    @DisplayName("POST /api/admin/meetings/complete-expired - 응답 메시지 확인")
+    void completeExpiredMeetings_ResponseMessage() throws Exception {
+        // given
+        doNothing().when(meetingStatusScheduler).updateExpiredMeetingsToCompleted();
+
+        // when & then
+        MvcResult mvcResult = mockMvc.perform(
+            post("/api/admin/meetings/complete-expired")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value(200))
+            .andExpect(jsonPath("$.body").value("만료된 미팅들의 상태가 성공적으로 COMPLETED로 변경되었습니다."))
+            .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        log.info("Response Message Test: {}", responseBody);
+
+        verify(meetingStatusScheduler, times(1)).updateExpiredMeetingsToCompleted();
+    }
+}

--- a/src/test/java/sevenstar/marineleisure/meeting/service/util/MeetingStatusSchedulerTest.java
+++ b/src/test/java/sevenstar/marineleisure/meeting/service/util/MeetingStatusSchedulerTest.java
@@ -1,0 +1,244 @@
+package sevenstar.marineleisure.meeting.service.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import sevenstar.marineleisure.global.enums.MeetingStatus;
+import sevenstar.marineleisure.meeting.domain.Meeting;
+import sevenstar.marineleisure.meeting.repository.MeetingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingStatusSchedulerTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @InjectMocks
+    private MeetingStatusScheduler meetingStatusScheduler;
+
+    private Meeting expiredMeeting1;
+    private Meeting expiredMeeting2;
+    private Meeting expiredMeeting3;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime pastTime = LocalDateTime.now().minusHours(2);
+        
+        expiredMeeting1 = Meeting.builder()
+            .id(1L)
+            .title("만료된 모집중 미팅")
+            .hostId(1L)
+            .spotId(1L)
+            .status(MeetingStatus.RECRUITING)
+            .capacity(5)
+            .meetingTime(pastTime)
+            .build();
+
+        expiredMeeting2 = Meeting.builder()
+            .id(2L)
+            .title("만료된 진행중 미팅")
+            .hostId(2L)
+            .spotId(1L)
+            .status(MeetingStatus.ONGOING)
+            .capacity(5)
+            .meetingTime(pastTime.minusHours(1))
+            .build();
+
+        expiredMeeting3 = Meeting.builder()
+            .id(3L)
+            .title("만료된 모집완료 미팅")
+            .hostId(3L)
+            .spotId(1L)
+            .status(MeetingStatus.FULL)
+            .capacity(5)
+            .meetingTime(pastTime.minusMinutes(30))
+            .build();
+    }
+
+    @Test
+    @DisplayName("만료된 미팅들을 COMPLETED 상태로 성공적으로 변경")
+    void updateExpiredMeetingsToCompleted_Success() {
+        // given
+        List<Meeting> expiredMeetings = Arrays.asList(expiredMeeting1, expiredMeeting2, expiredMeeting3);
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(expiredMeetings);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        verify(meetingRepository).findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED));
+        
+        // 각 미팅의 상태가 COMPLETED로 변경되었는지 확인
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        List<Meeting> savedMeetings = meetingCaptor.getValue();
+        assertEquals(3, savedMeetings.size());
+        assertEquals(MeetingStatus.COMPLETED, savedMeetings.get(0).getStatus());
+        assertEquals(MeetingStatus.COMPLETED, savedMeetings.get(1).getStatus());
+        assertEquals(MeetingStatus.COMPLETED, savedMeetings.get(2).getStatus());
+    }
+
+    @Test
+    @DisplayName("만료된 미팅이 없을 때는 아무 작업 수행하지 않음")
+    void updateExpiredMeetingsToCompleted_NoExpiredMeetings() {
+        // given
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(Collections.emptyList());
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        verify(meetingRepository).findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED));
+        verify(meetingRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("단일 만료된 미팅 처리")
+    void updateExpiredMeetingsToCompleted_SingleMeeting() {
+        // given
+        List<Meeting> expiredMeetings = Arrays.asList(expiredMeeting1);
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(expiredMeetings);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        verify(meetingRepository).findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED));
+        
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        List<Meeting> savedMeetings = meetingCaptor.getValue();
+        assertEquals(1, savedMeetings.size());
+        assertEquals(MeetingStatus.COMPLETED, savedMeetings.get(0).getStatus());
+        assertEquals(1L, savedMeetings.get(0).getId());
+    }
+
+    @Test
+    @DisplayName("RECRUITING 상태 미팅이 COMPLETED로 변경")
+    void updateExpiredMeetingsToCompleted_RecruitingToCompleted() {
+        // given
+        List<Meeting> expiredMeetings = Arrays.asList(expiredMeeting1);
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(expiredMeetings);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        Meeting savedMeeting = meetingCaptor.getValue().get(0);
+        assertEquals(MeetingStatus.COMPLETED, savedMeeting.getStatus());
+        assertEquals("만료된 모집중 미팅", savedMeeting.getTitle());
+    }
+
+    @Test
+    @DisplayName("ONGOING 상태 미팅이 COMPLETED로 변경")
+    void updateExpiredMeetingsToCompleted_OngoingToCompleted() {
+        // given
+        List<Meeting> expiredMeetings = Arrays.asList(expiredMeeting2);
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(expiredMeetings);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        Meeting savedMeeting = meetingCaptor.getValue().get(0);
+        assertEquals(MeetingStatus.COMPLETED, savedMeeting.getStatus());
+        assertEquals("만료된 진행중 미팅", savedMeeting.getTitle());
+    }
+
+    @Test
+    @DisplayName("FULL 상태 미팅이 COMPLETED로 변경")
+    void updateExpiredMeetingsToCompleted_FullToCompleted() {
+        // given
+        List<Meeting> expiredMeetings = Arrays.asList(expiredMeeting3);
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(expiredMeetings);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        Meeting savedMeeting = meetingCaptor.getValue().get(0);
+        assertEquals(MeetingStatus.COMPLETED, savedMeeting.getStatus());
+        assertEquals("만료된 모집완료 미팅", savedMeeting.getTitle());
+    }
+
+    @Test
+    @DisplayName("Repository 메서드가 올바른 파라미터로 호출되는지 확인")
+    void updateExpiredMeetingsToCompleted_CorrectParameters() {
+        // given
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(Collections.emptyList());
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        ArgumentCaptor<LocalDateTime> timeCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<MeetingStatus> statusCaptor = ArgumentCaptor.forClass(MeetingStatus.class);
+        
+        verify(meetingRepository).findExpiredMeetingsNotCompleted(timeCaptor.capture(), statusCaptor.capture());
+        
+        assertEquals(MeetingStatus.COMPLETED, statusCaptor.getValue());
+        assertNotNull(timeCaptor.getValue());
+        // 현재 시간과 거의 비슷한 시간이 전달되었는지 확인 (5초 이내 차이)
+        assertTrue(Math.abs(timeCaptor.getValue().compareTo(LocalDateTime.now())) < 5);
+    }
+
+    @Test
+    @DisplayName("대량의 만료된 미팅 처리")
+    void updateExpiredMeetingsToCompleted_LargeAmount() {
+        // given
+        List<Meeting> largeMeetingList = Arrays.asList(
+            expiredMeeting1, expiredMeeting2, expiredMeeting3,
+            expiredMeeting1, expiredMeeting2 // 5개 미팅
+        );
+        when(meetingRepository.findExpiredMeetingsNotCompleted(any(LocalDateTime.class), eq(MeetingStatus.COMPLETED)))
+            .thenReturn(largeMeetingList);
+
+        // when
+        meetingStatusScheduler.updateExpiredMeetingsToCompleted();
+
+        // then
+        ArgumentCaptor<List<Meeting>> meetingCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meetingRepository).saveAll(meetingCaptor.capture());
+        
+        List<Meeting> savedMeetings = meetingCaptor.getValue();
+        assertEquals(5, savedMeetings.size());
+        
+        // 모든 미팅이 COMPLETED 상태로 변경되었는지 확인
+        savedMeetings.forEach(meeting -> 
+            assertEquals(MeetingStatus.COMPLETED, meeting.getStatus())
+        );
+    }
+}


### PR DESCRIPTION
- [v] 💯 테스트는 잘 통과했나요?  
- [v] 🏗️ 빌드는 성공했나요?  
- [v] 🧹 불필요한 코드는 제거했나요?  
- [v] 💭 이슈는 등록했나요?  
- [v] 🏷️ 라벨은 등록했나요?  

## 작업 내용
- **관리자용 미팅 상태 수동/스케줄러 기능 추가**  
  - `MeetingSchedulerController` (`/api/admin/meetings/complete-expired`)  
    - POST 요청 시 만료된 미팅 상태를 `COMPLETED`로 변경하는 엔드포인트 구현  
  - `MeetingStatusScheduler` (10분마다 실행되는 스케줄러)  
    - `@Scheduled(cron = "0 */10 * * * *")` 애노테이션으로 주기적 상태 변경 로직 등록  
    - `meetingRepository.findExpiredMeetingsNotCompleted(now, MeetingStatus.COMPLETED)` 호출 후 `changeStatus(COMPLETED)` 및 `saveAll` 처리  
  - **Repository**  
    - `findExpiredMeetingsNotCompleted(LocalDateTime now, MeetingStatus skipStatus)` 메서드 활용  
  - **테스트 코드**  
    - **MeetingSchedulerControllerTest**:  
      1. 성공 케이스 (200 OK)  
      2. 예외 발생 시 500 Internal Server Error  
      3. 여러 번 연속 호출 시 정상 동작  
      4. 잘못된 HTTP 메서드/URL 접근 시 405/404  
      5. Content-Type, 응답 메시지 검증  
    - **MeetingStatusSchedulerTest**:  
      1. 만료된 미팅 처리 성공  
      2. 만료된 미팅 없을 때 동작 없음  
      3. 단일·다중 미팅 상태 변경 검증  
      4. `findExpiredMeetingsNotCompleted` 파라미터·호출 횟수 검증  
      5. 대량 처리 시 퍼포먼스 검증 (목록 크기 일치)

## 스크린샷
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/40fa2c5b-ad08-43b7-a92e-3befcbac1fd8" />


## 주의사항
- **보안**: `/api/admin` 경로는 관리자 권한이 필요하므로, 인증·인가 설정 확인 필요  
- **크론 주기 변경**: 운영 환경 부하를 고려해 `cron` 스케줄을 조정해야 할 수 있습니다.  
- **테스트 환경**: Controller 테스트에서 `SecurityAutoConfiguration`을 제외했으므로, 실제 배포 전 제대로 된 보안 필터가 적용되는지 검증하세요.  


Closes #139 
